### PR TITLE
fix(vercel): add rewrites for SPA client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "buildCommand": "cd app && npx convex deploy --cmd 'npm run build' --preview-run 'seed:runSeed'",
   "installCommand": "cd app && npm install",
-  "outputDirectory": "app/dist"
+  "outputDirectory": "app/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #67. This PR adds a rewrite rule to vercel.json to ensure that direct navigation to sub-routes (e.g., /admin/moderation) does not result in a 404 error by serving index.html for all non-static paths, allowing React Router to handle the routing on the client side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Add SPA client-side routing support on Vercel** — Implements rewrite rule in `vercel.json` to serve `index.html` for all non-static paths, enabling React Router to handle nested route resolution and preventing 404 errors on direct navigation to client-side routes (e.g., `/admin/moderation`)
- Resolves #67: Direct navigation to nested routes now functions correctly without returning 404 errors

## Contributor Statistics

| Author | Lines Added | Lines Removed |
|--------|------------|---------------|
| Marco Smith | 11 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->