### PR TITLE
fix: resolve 'multiple paginated queries' error in admin stats

### DIFF
--- a/app/convex/admin.ts
+++ b/app/convex/admin.ts
@@ -386,7 +386,12 @@ export const getAuditLogs = query({
  * Uses .collect() which is suitable for moderate datasets in this prototype.
  * @param query - A Convex query object
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * Count the number of results produced by a query using its `collect()` method.
+ *
+ * @param query - A query-like object exposing `collect()` which returns an array of results
+ * @returns The number of results returned by `query.collect()`
+ */
 async function countQuery(query: any) {
   const results = await query.collect();
   return results.length;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Fix: resolve "multiple paginated queries" error in admin stats by replacing manual paginate-loop counting with query.collect()-based counting in countQuery(), simplifying logic and removing continueCursor handling
- Improve reliability of dashboard statistics counting for moderate datasets
- Update countQuery() signature to accept a generic query and document collect()-based usage

## Changes by Author

| Author | Additions | Deletions |
|--------|-----------:|----------:|
| Marco Smith | 13 | 17 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->