### PR TITLE
chore: add environment-aware build logic for Convex deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "cd app && bunx convex deploy --cmd 'bun run build' --preview-run 'seed:runSeed'",
+  "buildCommand": "cd app && if [ \"$VERCEL_ENV\" = \"production\" ]; then bunx convex deploy --cmd 'bun run build'; else bun run build; fi",
   "installCommand": "cd app && bun install",
   "outputDirectory": "app/dist",
   "rewrites": [


### PR DESCRIPTION
## Summary

- Updates `vercel.json` buildCommand to conditionally deploy Convex only on production environments
- For preview deployments, only runs `bun run build` without Convex deployment
- This prevents repeated seeding operations on the shared development database
- Requires manual Vercel/Convex dashboard configuration for preview environment variables and CORS settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Environment-aware build logic for Convex deployment: Production builds now run `bunx convex deploy --cmd 'bun run build'` while preview deployments run only `bun run build` to prevent repeated seeding on the shared development database
- Conditional deployment based on `VERCEL_ENV` variable, automatically skipping Convex deployment in non-production environments
- Preview environments require manual configuration of Vercel/Convex dashboard variables and CORS settings

## Contribution Summary

| Author | Files Changed | Insertions | Deletions |
|--------|---------------|-----------|----------|
| Marco Smith | 280 | +38,620 | - |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->