### PR TITLE
fix: simplify context types to resolve TypeScript instantiation error

### DIFF
--- a/app/src/contexts/admin-stats-types.ts
+++ b/app/src/contexts/admin-stats-types.ts
@@ -11,6 +11,6 @@ export interface AdminStats {
 
 export const NO_PROVIDER = Symbol("NO_PROVIDER");
 
-export const AdminStatsContext = createContext<
-  AdminStats | undefined | null | typeof NO_PROVIDER
->(NO_PROVIDER);
+export const AdminStatsContext = createContext<AdminStats | undefined | null>(
+  NO_PROVIDER as unknown as AdminStats | undefined | null
+);

--- a/app/src/contexts/useAdminStats.ts
+++ b/app/src/contexts/useAdminStats.ts
@@ -9,7 +9,7 @@ import { AdminStatsContext, NO_PROVIDER } from "./admin-stats-types";
  */
 export function useAdminStats() {
   const context = useContext(AdminStatsContext);
-  if (context === NO_PROVIDER) {
+  if ((context as unknown) === NO_PROVIDER) {
     throw new Error("useAdminStats must be used within an AdminStatsProvider");
   }
   return context;

--- a/app/src/contexts/useUserProfile.ts
+++ b/app/src/contexts/useUserProfile.ts
@@ -10,7 +10,7 @@ import { UserProfileContext, NO_PROVIDER } from "./user-profile-types";
 export function useUserProfile() {
   const context = useContext(UserProfileContext);
   // Throw if sentinel to ensure usage within provider
-  if (context === NO_PROVIDER) {
+  if ((context as unknown) === NO_PROVIDER) {
     throw new Error("useUserProfile must be used within a UserProfileProvider");
   }
   return context;

--- a/app/src/contexts/user-profile-types.ts
+++ b/app/src/contexts/user-profile-types.ts
@@ -34,6 +34,6 @@ export interface UserProfile {
 
 export const NO_PROVIDER = Symbol("NO_PROVIDER");
 
-export const UserProfileContext = createContext<
-  UserProfile | undefined | null | typeof NO_PROVIDER
->(NO_PROVIDER);
+export const UserProfileContext = createContext<UserProfile | undefined | null>(
+  NO_PROVIDER as unknown as UserProfile | undefined | null
+);


### PR DESCRIPTION
## Summary
- Removes `typeof NO_PROVIDER` from context type unions to fix "Type instantiation is excessively deep and possibly infinite" TypeScript error
- Uses double type casting (`as unknown as T`) for runtime sentinel value while keeping type system simple
- Updates both AdminStatsContext and UserProfileContext with their respective hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Changes
- **Simplified context type definitions** for `AdminStatsContext` and `UserProfileContext` by removing `typeof NO_PROVIDER` from type unions, resolving TypeScript "Type instantiation is excessively deep and possibly infinite" error
- **Updated context initialization** to use double type casting (`as unknown as T`) for the `NO_PROVIDER` sentinel value, maintaining runtime behavior while simplifying the type system
- **Modified context consumer hooks** (`useAdminStats` and `useUserProfile`) to cast context to unknown before comparing against `NO_PROVIDER` sentinel
- **Created context provider components** wrapping the simplified context with type-safe consumer hooks

### Lines Changed by Contributor

| Author | Additions | Deletions |
|--------|-----------|-----------|
| Marco Smith | 134 | 0 |

**File Breakdown:**
- `app/src/contexts/admin-stats-types.ts`: +16
- `app/src/contexts/AdminStatsContext.tsx`: +23
- `app/src/contexts/useAdminStats.ts`: +16
- `app/src/contexts/user-profile-types.ts`: +39
- `app/src/contexts/UserProfileContext.tsx`: +23
- `app/src/contexts/useUserProfile.ts`: +17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->