### PR TITLE
fix(convex): resolve duplicate auction index and update PII_ENCRYPTION_KEY placeholder

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -10,3 +10,6 @@ BETTER_AUTH_URL=http://localhost:5173
 # Comma-separated list of allowed origins for cross-origin requests
 # Omitting this will block all CORS requests
 ALLOWED_ORIGINS=http://localhost:5173
+
+# Cryptographically secure 32-byte key for PII encryption (e.g., openssl rand -hex 32)
+PII_ENCRYPTION_KEY="GENERATE_SECURE_32_BYTE_HEX_KEY_HERE"

--- a/app/convex/auctions/internal.ts
+++ b/app/convex/auctions/internal.ts
@@ -81,7 +81,7 @@ export const cleanupDraftsHandler = async (ctx: MutationCtx) => {
   // Process in batches to avoid hitting Convex limits
   const oldDrafts = await ctx.db
     .query("auctions")
-    .withIndex("by_status_creationTime", (q) =>
+    .withIndex("by_status", (q) =>
       q.eq("status", "draft").lte("_creationTime", cutoffTime)
     )
     .take(CLEANUP_BATCH_SIZE);

--- a/app/convex/schema.ts
+++ b/app/convex/schema.ts
@@ -60,7 +60,6 @@ export default defineSchema({
     ),
   })
     .index("by_status", ["status"])
-    .index("by_status_creationTime", ["status"])
     .index("by_seller", ["sellerId"])
     .index("by_seller_status", ["sellerId", "status"])
     .index("by_end_time", ["endTime"])


### PR DESCRIPTION
This PR resolves a duplicate index error in Convex and updates a weak PII_ENCRYPTION_KEY placeholder in .env.example.

### Changes:
- **Convex Schema:** Removed redundant 'by_status_creationTime' index from the 'auctions' table. Convex automatically appends '_creationTime' to all indexes, making this one identical to 'by_status'.
- **Convex Functions:** Updated 'cleanupDraftsHandler' to use the 'by_status' index for querying draft status and creation time.
- **Environment:** Updated 'PII_ENCRYPTION_KEY' in '.env.example' with a more secure placeholder as suggested by CodeRabbit.

Verified with linting and builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Bug Fixes
- **Resolved duplicate auction index**: Removed the redundant `by_status_creationTime` index from the Convex auctions schema. Convex automatically appends `_creationTime` to indexes, making this index identical to the `by_status` index.
- **Updated cleanupDraftsHandler**: Modified the draft cleanup query to use the `by_status` index instead of the removed `by_status_creationTime` index, maintaining full functionality.
- **Enhanced .env.example**: Replaced the weak `PII_ENCRYPTION_KEY` placeholder with a more secure value that aligns with cryptographic best practices for 32-byte keys.

### Changes by Author

| Author | Files Changed | Lines Added | Lines Removed |
|--------|---------------|-------------|---------------|
| marcojsmith | 3 | 4 | 2 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->