### PR TITLE
fix(admin): rename Live Users to Online Users in KPI header strip (#74)

### DIFF
--- a/Checklist.md
+++ b/Checklist.md
@@ -165,7 +165,7 @@
 - [x] Fix inconsistent user count data (#139)
 - [x] Fix real-time loading in Live Monitor (#138)
 - [x] Fix KPI data accuracy (#63)
-- [x] Replace "Verified Users" KPI with "Online Users" (#74)
+- [x] Replace "Live Users" KPI with "Online Users" (#74)
 - [x] Integrate KYC pending count into User Base summary (#71)
 - [x] Fix 200 auction limit in admin stats for accurate analytics review (#81)
 - [ ] Implement platform fee configuration page (out-of-scope — payment removal) (#106)

--- a/src/components/admin/AdminLayout.test.tsx
+++ b/src/components/admin/AdminLayout.test.tsx
@@ -110,7 +110,7 @@ describe("AdminLayout", () => {
         <div>Test Content</div>
       </AdminLayout>
     );
-    const statLabels = screen.getAllByText("Live Users");
+    const statLabels = screen.getAllByText("Online Users");
     expect(statLabels.length).toBeGreaterThan(0);
   });
 
@@ -121,7 +121,7 @@ describe("AdminLayout", () => {
         <div>Test Content</div>
       </AdminLayout>
     );
-    expect(screen.queryByText("Live Users")).not.toBeInTheDocument();
+    expect(screen.queryByText("Online Users")).not.toBeInTheDocument();
   });
 
   it("does not render stat cards when stats are undefined", () => {
@@ -131,7 +131,7 @@ describe("AdminLayout", () => {
         <div>Test Content</div>
       </AdminLayout>
     );
-    expect(screen.queryByText("Live Users")).not.toBeInTheDocument();
+    expect(screen.queryByText("Online Users")).not.toBeInTheDocument();
   });
 
   it("renders Announce button when onAnnounce callback is provided", () => {

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -154,7 +154,7 @@ function AdminLayoutContent({
               {stats && (
                 <div className="flex flex-wrap gap-2">
                   <StatCard
-                    label="Live Users"
+                    label="Online Users"
                     value={stats.liveUsers}
                     icon={<Activity className="h-3 w-3" />}
                     color="text-green-500"


### PR DESCRIPTION
## Summary

- Renamed "Live Users" label to "Online Users" in admin KPI header strip
- Updated corresponding tests to match the new label
- Fixed Checklist.md entry to reference correct original value

## Changes

- `src/components/admin/AdminLayout.tsx` - Changed label prop from "Live Users" to "Online Users"
- `src/components/admin/AdminLayout.test.tsx` - Updated test assertions
- `Checklist.md` - Fixed checklist entry

## Testing

- All 12 AdminLayout tests pass
- Lint and build pass

Closes #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Renamed "Live Users" to "Online Users" in the admin KPI header strip for improved terminology consistency
- Updated all corresponding test assertions to reflect the new label
- Corrected checklist entry to reference the correct original KPI label being replaced

**Related issue:** #74

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| marcojsmith | 5 | 5 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->