### PR TITLE
fix: add activeListings to getSellerInfo return validator

### DIFF
--- a/convex/auctions/queries/browse.ts
+++ b/convex/auctions/queries/browse.ts
@@ -449,6 +449,7 @@ export const getSellerInfo = query({
       role: v.string(),
       createdAt: v.optional(v.number()),
       itemsSold: v.number(),
+      activeListings: v.number(),
       totalListings: v.number(),
       bio: v.optional(v.string()),
       companyName: v.optional(v.string()),


### PR DESCRIPTION
## Summary

- `getSellerInfo` in `convex/auctions/queries/browse.ts` was returning an `activeListings` field that was not declared in the `returns` validator
- This caused a `ReturnsValidationError` on the profile page (`/profile/...`) and auction pages, logged to the `errorReports` table
- Fix adds `activeListings: v.number()` to the return validator to match what the handler already returns

## Root cause

The handler and its unit tests were correct — tests even asserted on `activeListings`. The mismatch was invisible to the test suite because unit tests call the handler directly, bypassing the Convex framework's runtime validator enforcement.

## Test plan

- [ ] Navigate to a seller profile page and verify no `ReturnsValidationError` is thrown
- [ ] Navigate to an auction page and verify seller info loads without error
- [ ] Confirm no new entries appear in the `errorReports` table for this error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Fixed `ReturnsValidationError` on seller profile and auction pages** by adding missing `activeListings` field to the `getSellerInfo` query return validator
- **Prevents erroneous error logs** that were accumulating in the `errorReports` table due to the validator mismatch
- **Validator now matches handler output** — the `activeListings` field was being returned by the handler but was undeclared in the return schema

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| marcojsmith | 1 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->