### PR TITLE
feat: profile page UI refresh — mobile-first, less cards, sharper corners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,11 +141,13 @@ Consult these regularly. Keep them accurate when making changes.
 1. **Clarity** — Clear labels, tooltips, prominent key information (highest bid, time remaining).
 2. **Consistency** — Uniform styles per `conductor/product-guidelines.md`. Use theme tokens, never hardcoded colours/fonts.
 3. **Accessibility** — ARIA roles, keyboard navigation, semantic HTML.
-4. **Responsiveness** — Mobile (375×812), Tablet (768×1024), Desktop (1440×900).
+4. **Mobile-first** — Design for 375×812 first, then scale up to tablet (768×1024) and desktop (1440×900). Every layout, spacing, and component decision must work well on mobile before being enhanced for larger screens. Use Tailwind's unprefixed classes for mobile, then `sm:`, `md:`, `lg:` to progressively enhance.
 5. **Feedback** — Loading indicators, success/error messages for all user actions.
 6. **Simplicity** — No clutter. Every element must earn its place.
 7. **Components** — Use shadcn/ui. Install from the library first, customise as needed.
 8. **Verify with MCP** — Always test UI changes across breakpoints before committing.
+9. **Restraint** — Prefer flat sections with dividers over wrapping every block in a `<Card>`. Cards are for content that genuinely needs visual isolation. Avoid card-in-card patterns.
+10. **Sharpness** — Use `rounded` (4px) or `rounded-md` (6px) for UI elements. Reserve `rounded-lg` (8px) for images and avatars. Avoid `rounded-xl`, `rounded-2xl` on layout containers and buttons — they read as playful, not professional.
 
 ---
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -198,7 +198,7 @@ export default function Profile() {
           The profile you are looking for does not exist or has been
           deactivated.
         </p>
-        <Button asChild variant="outline" className="rounded-xl border-2">
+        <Button asChild variant="outline" className="rounded-md border-2">
           <Link to="/">
             <ArrowLeft className="mr-2 h-4 w-4" /> Back to Marketplace
           </Link>
@@ -213,16 +213,16 @@ export default function Profile() {
   const trustItems = getTrustItems(sellerInfo.isVerified);
 
   return (
-    <div className="max-w-7xl mx-auto space-y-8 p-6">
-      <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8">
-        {/* Sidebar */}
-        <aside className="space-y-6">
-          {/* Profile Card */}
-          <Card className="bg-card border border-primary/10 rounded-2xl overflow-hidden">
-            <div className="h-20 bg-gradient-to-br from-primary to-accent" />
-            <CardContent className="p-6">
+    <div className="max-w-7xl mx-auto space-y-8 px-4 py-4 sm:p-6">
+      <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-6 lg:gap-8">
+        {/* Sidebar — single merged card */}
+        <aside>
+          <Card className="bg-card border border-primary/10 rounded-lg overflow-hidden">
+            {/* Profile header */}
+            <div className="h-14 sm:h-20 bg-gradient-to-br from-primary to-accent" />
+            <CardContent className="p-4 sm:p-6">
               <div className="flex items-center gap-4 -mt-10 mb-4">
-                <div className="h-16 w-16 rounded-xl bg-primary/10 flex items-center justify-center border-4 border-card shadow-md">
+                <div className="h-16 w-16 rounded-md bg-primary/10 flex items-center justify-center border-4 border-card shadow-md">
                   <span className="text-xl font-black text-primary">
                     {getInitials(sellerInfo.name)}
                   </span>
@@ -273,65 +273,63 @@ export default function Profile() {
                 </p>
               )}
             </CardContent>
-          </Card>
 
-          {/* Stats Card */}
-          <Card className="bg-card border border-primary/10 rounded-2xl">
-            <CardContent className="p-5">
-              <div className="grid grid-cols-2 gap-3">
-                <div className="bg-muted/50 rounded-xl p-3 text-center">
-                  <p className="text-2xl font-black text-primary">
-                    {sellerInfo.activeListings}
-                  </p>
-                  <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
-                    Active
-                  </p>
-                </div>
-                <div className="bg-muted/50 rounded-xl p-3 text-center">
-                  <p className="text-2xl font-black text-green-600">
-                    {sellerInfo.itemsSold}
-                  </p>
-                  <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
-                    Sold
-                  </p>
-                </div>
-                <div className="bg-muted/50 rounded-xl p-3 text-center">
-                  <p className="text-2xl font-black text-primary">
-                    {formatPrice(sellerInfo.avgSalePrice)}
-                  </p>
-                  <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
-                    Avg Sale
-                  </p>
-                </div>
-                <div className="bg-muted/50 rounded-xl p-3 text-center">
-                  <p className="text-2xl font-black text-primary">
-                    {sellerInfo.bidsPlaced}
-                  </p>
-                  <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
-                    Bids
-                  </p>
-                </div>
+            {/* Stats */}
+            <div className="h-px bg-border" />
+            <div className="grid grid-cols-4 divide-x divide-border">
+              <div className="p-3 text-center">
+                <p className="text-xl font-black text-primary">
+                  {sellerInfo.activeListings}
+                </p>
+                <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
+                  Active
+                </p>
               </div>
-
-              <div className="bg-muted/50 rounded-xl p-3 mt-3 flex items-center justify-between">
-                <div>
-                  <p className="text-amber-500 tracking-widest">★★★★★</p>
-                  <p className="text-[10px] text-muted-foreground">
-                    No reviews yet
-                  </p>
-                </div>
-                <p className="text-xl font-black text-muted-foreground">—</p>
+              <div className="p-3 text-center">
+                <p className="text-xl font-black text-green-600">
+                  {sellerInfo.itemsSold}
+                </p>
+                <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
+                  Sold
+                </p>
               </div>
-            </CardContent>
-          </Card>
+              <div className="p-3 text-center">
+                <p className="text-xl font-black text-primary">
+                  {formatPrice(sellerInfo.avgSalePrice)}
+                </p>
+                <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
+                  Avg Sale
+                </p>
+              </div>
+              <div className="p-3 text-center">
+                <p className="text-xl font-black text-primary">
+                  {sellerInfo.bidsPlaced}
+                </p>
+                <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest">
+                  Bids
+                </p>
+              </div>
+            </div>
 
-          {/* Action Buttons */}
-          <Card className="bg-card border border-primary/10 rounded-2xl">
-            <CardContent className="p-5 space-y-3">
+            {/* Rating row */}
+            <div className="h-px bg-border" />
+            <div className="px-4 py-3 flex items-center justify-between">
+              <div>
+                <p className="text-amber-500 tracking-widest">★★★★★</p>
+                <p className="text-[10px] text-muted-foreground">
+                  No reviews yet
+                </p>
+              </div>
+              <p className="text-xl font-black text-muted-foreground">—</p>
+            </div>
+
+            {/* Action buttons */}
+            <div className="h-px bg-border" />
+            <div className="p-4 space-y-2">
               {isOwner && !sellerInfo.isVerified && (
                 // TODO(#219): Implement granular verification status fields in backend
                 <Button
-                  className="w-full bg-amber-500 hover:bg-amber-600 text-white font-black uppercase tracking-wider text-xs h-10"
+                  className="w-full bg-amber-500 hover:bg-amber-600 text-white font-black uppercase tracking-wider text-xs h-10 rounded-md"
                   disabled
                   title="Coming soon - see issue #219"
                 >
@@ -342,7 +340,7 @@ export default function Profile() {
               {isOwner && (
                 <Button
                   asChild
-                  className="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-black uppercase tracking-wider text-xs h-10"
+                  className="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-black uppercase tracking-wider text-xs h-10 rounded-md"
                 >
                   <Link to="/sell">
                     <Plus className="h-4 w-4 mr-2" />
@@ -355,7 +353,7 @@ export default function Profile() {
                   {/* TODO(#220): Implement messaging system in backend */}
                   <Button
                     variant="outline"
-                    className="w-full border-2 border-border hover:border-primary/30 bg-transparent font-black uppercase tracking-wider text-xs h-10"
+                    className="w-full border-2 border-border hover:border-primary/30 bg-transparent font-black uppercase tracking-wider text-xs h-10 rounded-md"
                     disabled
                     title="Coming soon - see issue #220"
                   >
@@ -365,7 +363,7 @@ export default function Profile() {
                   {/* TODO(#221): Implement report functionality in backend */}
                   <Button
                     variant="ghost"
-                    className="w-full text-muted-foreground hover:text-destructive font-bold uppercase tracking-wider text-xs h-10"
+                    className="w-full text-muted-foreground hover:text-destructive font-bold uppercase tracking-wider text-xs h-10 rounded-md"
                     disabled
                     title="Coming soon - see issue #221"
                   >
@@ -374,20 +372,18 @@ export default function Profile() {
                   </Button>
                 </>
               )}
-            </CardContent>
+            </div>
           </Card>
         </aside>
 
         {/* Main Content */}
         <main className="space-y-6">
           {/* Active Auctions */}
-          <Card className="bg-card border border-primary/10 rounded-2xl">
-            <CardContent className="p-6">
+          <Card className="bg-card border border-primary/10 rounded-lg">
+            <CardContent className="p-4 sm:p-6">
               <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-3">
-                  <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-                    <Gavel className="h-4 w-4 text-primary" />
-                  </div>
+                <div className="flex items-center gap-2">
+                  <Gavel className="h-4 w-4 text-primary" />
                   <h2 className="text-lg font-black uppercase tracking-wide text-primary">
                     Active Auctions
                   </h2>
@@ -399,7 +395,7 @@ export default function Profile() {
               </div>
 
               {activeListings.length === 0 && status === "Exhausted" ? (
-                <div className="border-2 border-dashed border-border rounded-xl p-12 text-center">
+                <div className="border-2 border-dashed border-border rounded p-12 text-center">
                   <p className="text-4xl mb-3">🚜</p>
                   <p className="text-muted-foreground font-bold uppercase tracking-widest italic text-sm">
                     No active auctions at this time.
@@ -423,13 +419,11 @@ export default function Profile() {
 
           {/* Past Sales */}
           {soldListings.length > 0 && (
-            <Card className="bg-card border border-primary/10 rounded-2xl">
-              <CardContent className="p-6">
+            <Card className="bg-card border border-primary/10 rounded-lg">
+              <CardContent className="p-4 sm:p-6">
                 <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center gap-3">
-                    <div className="h-8 w-8 rounded-full bg-green-500/10 flex items-center justify-center">
-                      <Award className="h-4 w-4 text-green-600" />
-                    </div>
+                  <div className="flex items-center gap-2">
+                    <Award className="h-4 w-4 text-green-600" />
                     <h2 className="text-lg font-black uppercase tracking-wide text-green-700">
                       Sales History
                     </h2>
@@ -456,100 +450,92 @@ export default function Profile() {
           )}
 
           {/* Recent Activity */}
-          <Card className="bg-card border border-primary/10 rounded-2xl">
-            <CardContent className="p-6">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="h-8 w-8 rounded-full bg-blue-500/10 flex items-center justify-center">
-                  <UserCheck className="h-4 w-4 text-blue-600" />
-                </div>
-                <h2 className="text-lg font-black uppercase tracking-wide text-primary">
-                  Recent Activity
-                </h2>
-              </div>
+          <section>
+            <div className="flex items-center gap-2 mb-4">
+              <UserCheck className="h-4 w-4 text-blue-600" />
+              <h2 className="text-lg font-black uppercase tracking-wide text-primary">
+                Recent Activity
+              </h2>
+            </div>
 
-              <div className="space-y-0">
-                {activityItems.map((item) => (
+            <div className="space-y-0">
+              {activityItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-start gap-3 py-3 border-b border-border last:border-0"
+                >
                   <div
-                    key={item.id}
-                    className="flex items-start gap-3 py-3 border-b border-border last:border-0"
+                    className={`h-9 w-9 rounded flex items-center justify-center flex-shrink-0 ${
+                      item.type === "account_created"
+                        ? "bg-blue-500/10"
+                        : item.type === "verification_requested"
+                          ? "bg-amber-500/10"
+                          : "bg-green-500/10"
+                    }`}
                   >
-                    <div
-                      className={`h-9 w-9 rounded-lg flex items-center justify-center flex-shrink-0 ${
+                    <UserCheck
+                      className={`h-4 w-4 ${
                         item.type === "account_created"
-                          ? "bg-blue-500/10"
+                          ? "text-blue-600"
                           : item.type === "verification_requested"
-                            ? "bg-amber-500/10"
-                            : "bg-green-500/10"
+                            ? "text-amber-600"
+                            : "text-green-600"
                       }`}
-                    >
-                      <UserCheck
-                        className={`h-4 w-4 ${
-                          item.type === "account_created"
-                            ? "text-blue-600"
-                            : item.type === "verification_requested"
-                              ? "text-amber-600"
-                              : "text-green-600"
-                        }`}
-                      />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-semibold text-foreground">
-                        {item.title}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {item.description}
-                      </p>
-                    </div>
-                    <p className="text-xs text-muted-foreground whitespace-nowrap">
-                      {item.date}
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-foreground">
+                      {item.title}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {item.description}
                     </p>
                   </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+                  <p className="text-xs text-muted-foreground whitespace-nowrap">
+                    {item.date}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
 
           {/* Trust & Compliance */}
-          <Card className="bg-card border border-primary/10 rounded-2xl">
-            <CardContent className="p-6">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-                  <ShieldCheck className="h-4 w-4 text-primary" />
-                </div>
-                <h2 className="text-lg font-black uppercase tracking-wide text-primary">
-                  Trust & Compliance
-                </h2>
-              </div>
+          <section>
+            <div className="flex items-center gap-2 mb-4">
+              <ShieldCheck className="h-4 w-4 text-primary" />
+              <h2 className="text-lg font-black uppercase tracking-wide text-primary">
+                Trust & Compliance
+              </h2>
+            </div>
 
-              <div className="grid grid-cols-3 gap-3">
-                {trustItems.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <div
-                      key={item.id}
-                      className="bg-muted/50 rounded-xl p-4 text-center"
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {trustItems.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <div
+                    key={item.id}
+                    className="border border-border rounded p-4 text-center"
+                  >
+                    <Icon
+                      className={`h-5 w-5 mx-auto mb-2 ${
+                        item.verified ? "text-green-600" : "text-amber-600"
+                      }`}
+                    />
+                    <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest mb-1">
+                      {item.label}
+                    </p>
+                    <p
+                      className={`text-xs font-bold ${
+                        item.verified ? "text-green-600" : "text-amber-600"
+                      }`}
                     >
-                      <Icon
-                        className={`h-5 w-5 mx-auto mb-2 ${
-                          item.verified ? "text-green-600" : "text-amber-600"
-                        }`}
-                      />
-                      <p className="text-[10px] font-black uppercase text-muted-foreground tracking-widest mb-1">
-                        {item.label}
-                      </p>
-                      <p
-                        className={`text-xs font-bold ${
-                          item.verified ? "text-green-600" : "text-amber-600"
-                        }`}
-                      >
-                        {item.value}
-                      </p>
-                    </div>
-                  );
-                })}
-              </div>
-            </CardContent>
-          </Card>
+                      {item.value}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
         </main>
       </div>
 
@@ -566,7 +552,7 @@ export default function Profile() {
               loadMore(6);
             }}
             disabled={status === "LoadingMore"}
-            className="rounded-2xl border-2 px-12 font-black uppercase tracking-widest"
+            className="rounded-md border-2 px-12 font-black uppercase tracking-widest"
           >
             {status === "LoadingMore" ? (
               <>


### PR DESCRIPTION
## Summary

- **Merged 3 sidebar cards into 1** — profile, stats, and actions consolidated with divider rows, eliminating visual clutter and reducing mobile scroll depth
- **Stats row** redesigned as a compact 4-column horizontal strip (`divide-x`) — no filled rounded cells, just clean numbers
- **Removed `<Card>` wrappers** from Recent Activity and Trust & Compliance — rendered as flat `<section>` elements; internal dividers/borders provide sufficient structure
- **Section headers** simplified — removed icon circle containers, inline icon next to heading only
- **Trust grid mobile fix** — `grid-cols-3` → `grid-cols-2 sm:grid-cols-3` (previously caused cramped layout on small screens)
- **Border-radius audit** — `rounded-2xl` → `rounded-lg` (cards), `rounded-xl` → `rounded` (cells/empty states), buttons → `rounded-md`
- **Mobile padding** tightened — `p-6` → `p-4 sm:p-6`, gradient header `h-20` → `h-14 sm:h-20`
- **`AGENTS.md` updated** — rule 4 now explicitly mobile-first; added rule 9 (Restraint: flat sections over cards) and rule 10 (Sharpness: no `rounded-xl`/`rounded-2xl` on layout elements)

## Test plan

- [ ] View a seller profile at `/profile/:userId` on mobile (375px) — sidebar card compact, Trust grid 2 cols, listings visible sooner
- [ ] View on desktop (1440px) — sidebar + main content layout structurally unchanged
- [ ] Verify no visual regressions on tablet (768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Changes

- **Mobile-first design refresh**: Updated UI design rules in AGENTS.md to explicitly prioritize 375×812 viewport first, with progressive enhancement for sm/md/lg breakpoints
- **Simplified sidebar layout**: Consolidated three separate cards (profile metadata, stats, action buttons) into a single merged sidebar block with divider rows to reduce visual clutter and improve mobile scroll depth
- **Redesigned stats display**: Changed stats row to a compact 4-column horizontal layout using `grid-cols-4 divide-x` with clean numeric display, removing filled rounded cells
- **Flattened section structure**: Converted "Recent Activity" and "Trust & Compliance" from `<Card>` components to plain `<section>` elements with internal dividers/borders for cleaner, less-layered design
- **Mobile-responsive grid fixes**: Updated Trust grid to use `grid-cols-2 sm:grid-cols-3` to prevent cramped small-screen layouts
- **Border-radius standardization**: Audit and update across UI:
  - Cards: `rounded-2xl` → `rounded-lg`
  - Cells/empty states: `rounded-xl` → `rounded`
  - Buttons: standardized to `rounded-md`
- **Tightened mobile spacing**: Reduced base padding from `p-6` to `p-4 sm:p-6` and gradient header height from `h-20` to `h-14 sm:h-20`
- **Updated design guidelines**: Added explicit mobile-first rule, new "Restraint" rule to prefer flat sections over cards, and expanded "Sharpness" rule to restrict rounding sizes on layout elements

### Related Issues

- Closes [#131](https://github.com/marcojsmith/AgriBid/issues/131) — Enhance profile page with more user details and stats

### Contribution Summary

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| marcojsmith | 153 | 165 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->