### PR TITLE
Merge hamburger menu into profile dropdown on mobile

### DIFF
--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -134,19 +134,6 @@ describe("Header", () => {
     consoleSpy.mockRestore();
   });
 
-  it("toggles mobile menu", () => {
-    renderHeader();
-    const toggleBtn = screen.getByLabelText("Toggle menu");
-
-    // Open
-    fireEvent.click(toggleBtn);
-    expect(screen.getByTestId("mobile-menu")).toBeInTheDocument();
-
-    // Close via MobileMenu mock callback
-    fireEvent.click(screen.getByText("Close"));
-    expect(screen.queryByTestId("mobile-menu")).not.toBeInTheDocument();
-  });
-
   it("applies active link styling", () => {
     renderHeader("/");
     const marketplaceLink = screen.getByText("Marketplace");

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,9 +1,7 @@
 // app/src/components/header/Header.tsx
-import { useState, useCallback } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Authenticated, Unauthenticated, useQuery } from "convex/react";
 import { api } from "convex/_generated/api";
-import { Menu, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { signOut } from "@/lib/auth-client";
@@ -13,13 +11,12 @@ import { NotificationDropdown } from "@/components/NotificationDropdown";
 
 import { SearchBar } from "./SearchBar";
 import { UserDropdown } from "./UserDropdown";
-import { MobileMenu } from "./MobileMenu";
 
 /**
  * Main application header component.
  *
- * Renders the site navigation, search bar, user authentication controls,
- * and mobile menu. This component is publicly exported via the header barrel.
+ * Renders the site navigation, search bar, and user authentication controls.
+ * This component is publicly exported via the header barrel.
  *
  * @returns A JSX.Element representing the application header
  */
@@ -33,11 +30,6 @@ export const Header = () => {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  const handleCloseMenu = useCallback(() => {
-    setIsMenuOpen(false);
-  }, []);
 
   const navLinks: { name: string; href: string; disabled?: boolean }[] = [
     { name: "Marketplace", href: "/" },
@@ -49,11 +41,11 @@ export const Header = () => {
   const handleSignOut = async () => {
     try {
       await signOut();
-      toast.success("Signed out successfully");
-      navigate("/");
+      void toast.success("Signed out successfully");
+      void navigate("/");
     } catch (err) {
       console.error("Sign out failed:", err);
-      toast.error("Failed to sign out. Please try again.");
+      void toast.error("Failed to sign out. Please try again.");
     }
   };
 
@@ -130,35 +122,8 @@ export const Header = () => {
               <Link to="/login">Login / Register</Link>
             </Button>
           </Unauthenticated>
-
-          {/* Mobile Menu Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden h-10 w-10 border-2 rounded-xl"
-            onClick={() => setIsMenuOpen(!isMenuOpen)}
-            aria-label="Toggle menu"
-          >
-            {isMenuOpen ? (
-              <X className="h-5 w-5" />
-            ) : (
-              <Menu className="h-5 w-5" />
-            )}
-          </Button>
         </div>
       </div>
-
-      <MobileMenu
-        isOpen={isMenuOpen}
-        onClose={handleCloseMenu}
-        navLinks={navLinks}
-        userData={userData}
-        isVerified={isVerified ?? false}
-        kycStatus={kycStatus}
-        role={role}
-        profileId={profileId}
-        onSignOut={handleSignOut}
-      />
     </header>
   );
 };

--- a/src/components/header/UserDropdown.test.tsx
+++ b/src/components/header/UserDropdown.test.tsx
@@ -91,7 +91,6 @@ describe("UserDropdown", () => {
 
   it("shows menu content (mocked directly)", () => {
     renderWithRouter();
-    expect(screen.getByText("Account Terminal")).toBeInTheDocument();
     expect(screen.getByText("My Bids")).toBeInTheDocument();
     expect(screen.getByText("Sign Out")).toBeInTheDocument();
   });

--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -1,5 +1,5 @@
 // app/src/components/header/UserDropdown.tsx
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { toast } from "sonner";
 import {
   User,
@@ -10,6 +10,8 @@ import {
   Settings,
   ShieldAlert,
   MessageSquare,
+  ShoppingBasket,
+  Tag,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -18,12 +20,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
 import type { UserDataWithProfile } from "@/types/auth";
+
+const navLinks = [
+  { name: "Marketplace", href: "/", icon: ShoppingBasket },
+  { name: "Sell", href: "/sell", icon: Tag },
+] as const;
 
 interface UserDropdownProps {
   userData: UserDataWithProfile | null | undefined;
@@ -59,6 +65,8 @@ export function UserDropdown({
   role,
   onSignOut,
 }: UserDropdownProps) {
+  const location = useLocation();
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -105,9 +113,27 @@ export function UserDropdown({
         align="end"
         className="w-64 rounded-2xl border-2 p-2 shadow-2xl"
       >
-        <DropdownMenuLabel className="font-black uppercase text-[10px] tracking-widest text-muted-foreground px-2 py-2">
-          Account Terminal
-        </DropdownMenuLabel>
+        {navLinks.map((link) => {
+          const Icon = link.icon;
+          const isActive = location.pathname === link.href;
+          return (
+            <DropdownMenuItem
+              key={link.name}
+              asChild
+              className="rounded-xl font-bold uppercase text-[10px] tracking-wide h-10"
+            >
+              <Link
+                to={link.href}
+                className={`flex items-center gap-2 w-full ${
+                  isActive ? "text-primary" : ""
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                {link.name}
+              </Link>
+            </DropdownMenuItem>
+          );
+        })}
         <DropdownMenuSeparator />
 
         {!isVerified && kycStatus !== "pending" && (

--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -115,7 +115,11 @@ export function UserDropdown({
       >
         {navLinks.map((link) => {
           const Icon = link.icon;
-          const isActive = location.pathname === link.href;
+          const isActive =
+            link.href === "/"
+              ? location.pathname === "/"
+              : location.pathname === link.href ||
+                location.pathname.startsWith(`${link.href}/`);
           return (
             <DropdownMenuItem
               key={link.name}

--- a/src/pages/admin/AdminSettings.test.tsx
+++ b/src/pages/admin/AdminSettings.test.tsx
@@ -110,14 +110,20 @@ describe("AdminSettings Page", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/admin/error-reporting");
   });
 
-  it("navigates to Platform Fees page when card is clicked", () => {
+  it("opens Platform Fees GitHub issue when card is clicked", () => {
+    vi.stubGlobal("open", vi.fn());
     (useQuery as Mock).mockReturnValue(mockAdminStats);
     renderPage();
 
     const card = screen.getByRole("button", { name: /Platform Fees/i });
     fireEvent.click(card);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/admin/fees");
+    expect(window.open).toHaveBeenCalledWith(
+      "https://github.com/marcojsmith/AgriBid/issues/56",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    vi.unstubAllGlobals();
   });
 
   it("handles keyboard activation (Enter) on settings cards", () => {


### PR DESCRIPTION
## Summary
- Removed hamburger menu from mobile view
- Merged navigation links (Marketplace, Sell) into the profile dropdown
- Kept same trigger style on mobile (avatar + name + verification badge)
- Removed "Account Terminal" text from dropdown
- Fixed duplicate "Support" links by removing from navLinks
- Moved navLinks constant outside component to avoid recreation on every render
- Updated tests to reflect UI changes

## Testing
- All tests pass
- Lint passes
- Type-check passes
- Build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Removed hamburger menu from mobile view — mobile menu component and related state removed from Header.
- Merged navigation links into profile dropdown — Marketplace and Sell moved into UserDropdown with route-aware active highlighting; preserved mobile trigger style (avatar + name + verification badge).
- Removed "Account Terminal" label from the profile dropdown.
- Removed duplicate "Support" link from navLinks.
- Moved navLinks constant outside component to avoid recreation on every render.
- Updated Platform Fees behavior — now opens external GitHub issue in a new tab (window.open).
- Tests updated to reflect UI changes: Header tests removed mobile-menu assertions; UserDropdown tests removed "Account Terminal" assertion and verify new links; AdminSettings tests updated for external link behavior.
- Lint, type-check, build, and test suite: all passing.

### Lines Changed by Author

| Author | Lines Added | Lines Removed |
|--------|-------------:|--------------:|
| Marco Smith | 869 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->