### PR TITLE
chore: correct JSDOC

### DIFF
--- a/convex/auctions/mutations/create.ts
+++ b/convex/auctions/mutations/create.ts
@@ -70,7 +70,7 @@ export const generateUploadUrl = mutation({
  * @param args.conditionChecklist.serviceHistory - The service history of the equipment.
  * @param args.conditionChecklist.notes - Additional notes on the condition.
  * @param args.isDraft - Whether the auction is a draft.
- * @param args.startTime
+ * @param args.startTime - Optional Unix timestamp (ms) at which the auction should open for bidding. Omit to start immediately upon activation.
  * @returns Promise<Id<"auctions">>
  */
 export const createAuctionHandler = async (
@@ -246,7 +246,7 @@ export const createAuction = mutation({
  * @param args.conditionChecklist.tires - The condition of the tires.
  * @param args.conditionChecklist.serviceHistory - The service history of the equipment.
  * @param args.conditionChecklist.notes - Additional notes on the condition.
- * @param args.startTime
+ * @param args.startTime - Optional Unix timestamp (ms) at which the auction should open for bidding. Omit to start immediately upon activation.
  * @returns Promise<Id<"auctions">>
  */
 export const saveDraftHandler = async (

--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -115,11 +115,7 @@ export function UserDropdown({
       >
         {navLinks.map((link) => {
           const Icon = link.icon;
-          const isActive =
-            link.href === "/"
-              ? location.pathname === "/"
-              : location.pathname === link.href ||
-                location.pathname.startsWith(`${link.href}/`);
+          const isActive = location.pathname === link.href;
           return (
             <DropdownMenuItem
               key={link.name}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -59,13 +59,7 @@ export default function AdminSettings() {
             title="Platform Fees"
             description="Configure commission rates and listing fees."
             icon={<TrendingUp />}
-            action={() =>
-              window.open(
-                "https://github.com/marcojsmith/AgriBid/issues/56",
-                "_blank",
-                "noopener,noreferrer"
-              )
-            }
+            action={() => navigate("/admin/fees")}
           />
           <SettingsCard
             title="Security Logs"

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -59,7 +59,13 @@ export default function AdminSettings() {
             title="Platform Fees"
             description="Configure commission rates and listing fees."
             icon={<TrendingUp />}
-            action={() => navigate("/admin/fees")}
+            action={() =>
+              window.open(
+                "https://github.com/marcojsmith/AgriBid/issues/56",
+                "_blank",
+                "noopener,noreferrer"
+              )
+            }
           />
           <SettingsCard
             title="Security Logs"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Changes

- **Documentation**: Updated JSDoc for the `startTime` parameter in auction handlers to clarify it is an optional Unix timestamp in milliseconds controlling when the auction opens for bidding, with omission starting the auction immediately upon activation
- **Navigation**: Changed `UserDropdown` link active state detection from prefix-based matching to exact path matching
- **Admin Settings**: Updated Platform Fees action to open GitHub issue #56 in a new window instead of internal routing

### Closes

- [#56](https://github.com/marcojsmith/AgriBid/issues/56)

### Lines Changed by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| Marco Smith | 10 | 8 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->