### PR TITLE
 Fix Issue #214 — isWatched hardcoded to false in related auctions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ You are a senior full-stack developer assisting in building **AgriBid** — a re
 | -------------------------------------------------- | --------------------------------------------------------------------------- |
 | `bun run dev`                                      | Start development server                                                    |
 | `bun run type-check`                               | Type check with tsgo (4.6x faster than tsc)                                 |
-| `bun run lint`                                     | Check code for errors                                                       |
+| `bun run lint`                                     | Check code for errors on all files                                          |
 | `bunx eslint path/to/directory.file.ts`            | Run linting on a specific file                                              |
 | `bun run test --run path/to/directory/file.ts`     | Run test for a specific file                                                |
 | `bun run test:coverage`                            | Run tests with coverage - saves to test-coverage/latest-coverage-output.txt |

--- a/ISSUES_CHECKLIST.md
+++ b/ISSUES_CHECKLIST.md
@@ -9,13 +9,13 @@ Prioritized by size and quick wins for efficient resolution.
 
 ### Priority: High
 
-- [ ] #214: bug: isWatched hardcoded to false in related auctions section of AuctionDetail
+- [x] #214: bug: isWatched hardcoded to false in related auctions section of AuctionDetail
   - _Description_: Related auction cards always show unwatched state regardless of user's watchlist
   - _Labels_: bug
 - [ ] #215: feat: Add startTime bounds validation for non-draft auction mutations
   - _Description_: Validate startTime is not in the past and not more than 1 year in the future
   - _Labels_: enhancement
-- [ ] #213: chore: Add missing @param descriptions for args.startTime in createAuction/saveDraft JSDoc
+- [x] #213: chore: Add missing @param descriptions for args.startTime in createAuction/saveDraft JSDoc
   - _Description_: Add meaningful descriptions to @param args.startTime entries in createAuctionHandler and saveDraftHandler JSDoc
   - _Labels_: None
 - [ ] #217: feat: Add og-image.png to public directory for SEO social previews

--- a/src/pages/AuctionDetail.tsx
+++ b/src/pages/AuctionDetail.tsx
@@ -100,6 +100,8 @@ export default function AuctionDetail() {
     auction?.make ? { make: auction.make, excludeId: auction._id } : "skip"
   );
 
+  const watchedAuctionIds = useQuery(api.watchlist.getWatchedAuctionIds, {});
+
   const flagAuction = useMutation(api.auctions.mutations.publish.flagAuction);
 
   const isOwner = session?.user?.id === auction?.sellerId;
@@ -446,7 +448,9 @@ export default function AuctionDetail() {
                     key={related._id}
                     auction={related}
                     viewMode="compact"
-                    isWatched={false}
+                    isWatched={
+                      watchedAuctionIds?.includes(related._id) ?? false
+                    }
                   />
                 ))}
               </div>

--- a/src/pages/admin/AdminSettings.test.tsx
+++ b/src/pages/admin/AdminSettings.test.tsx
@@ -110,20 +110,14 @@ describe("AdminSettings Page", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/admin/error-reporting");
   });
 
-  it("opens Platform Fees GitHub issue when card is clicked", () => {
-    vi.stubGlobal("open", vi.fn());
+  it("navigates to Platform Fees page when card is clicked", () => {
     (useQuery as Mock).mockReturnValue(mockAdminStats);
     renderPage();
 
     const card = screen.getByRole("button", { name: /Platform Fees/i });
     fireEvent.click(card);
 
-    expect(window.open).toHaveBeenCalledWith(
-      "https://github.com/marcojsmith/AgriBid/issues/56",
-      "_blank",
-      "noopener,noreferrer"
-    );
-    vi.unstubAllGlobals();
+    expect(mockNavigate).toHaveBeenCalledWith("/admin/fees");
   });
 
   it("handles keyboard activation (Enter) on settings cards", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Fixed **Issue #214**: `isWatched` property no longer hardcoded to false in related auctions; now fetches and uses actual watched auction state
- Fixed **Issue #213**: Added missing `@param` descriptions for `args.startTime` in `createAuction/saveDraft` JSDoc
- Updated `bun run lint` command documentation in AGENTS.md for clarity
- Updated AdminSettings test to verify client-side navigation to admin fees page instead of external GitHub issue link

## Changes by Author

| Author | Additions | Deletions |
|--------|-----------|-----------|
| Marco Smith | 10 | 12 |

### Related Issues
- Closes #214
- Closes #213

<!-- end of auto-generated comment: release notes by coderabbit.ai -->