### PR TITLE
feat(auctions): add startTime bounds validation (Issue #215)

### DIFF
--- a/ISSUES_CHECKLIST.md
+++ b/ISSUES_CHECKLIST.md
@@ -12,7 +12,7 @@ Prioritized by size and quick wins for efficient resolution.
 - [x] #214: bug: isWatched hardcoded to false in related auctions section of AuctionDetail
   - _Description_: Related auction cards always show unwatched state regardless of user's watchlist
   - _Labels_: bug
-- [ ] #215: feat: Add startTime bounds validation for non-draft auction mutations
+- [x] #215: feat: Add startTime bounds validation for non-draft auction mutations
   - _Description_: Validate startTime is not in the past and not more than 1 year in the future
   - _Labels_: enhancement
 - [x] #213: chore: Add missing @param descriptions for args.startTime in createAuction/saveDraft JSDoc

--- a/convex/auctions/helpers.ts
+++ b/convex/auctions/helpers.ts
@@ -1,9 +1,15 @@
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 
 import type { QueryCtx } from "../_generated/server";
 import type { Doc } from "../_generated/dataModel";
 import { resolveUrlCached } from "../image_cache";
 import { findUserById } from "../users";
+import {
+  STARTTIME_MAX_PAST_MS,
+  STARTTIME_MAX_FUTURE_MS,
+  STARTTIME_ADMIN_MAX_PAST_MS,
+  STARTTIME_ADMIN_MAX_FUTURE_MS,
+} from "../constants";
 
 export interface RawImages {
   front?: string;
@@ -312,6 +318,42 @@ export function validateAuctionStatus(
   if (newStatus === "active" && !auction.endTime) {
     throw new Error(
       "Cannot set status to 'active' without endTime. Use approveAuction or provide endTime in the update."
+    );
+  }
+}
+
+/**
+ * Validates startTime bounds for auction scheduling.
+ * Sellers have stricter limits than admins.
+ *
+ * @param startTime - Unix timestamp (ms) to validate
+ * @param isAdminAction - Whether this is an admin action (broader limits)
+ */
+export function validateStartTimeBounds(
+  startTime: number,
+  isAdminAction: boolean
+): void {
+  const now = Date.now();
+  const maxPast = isAdminAction
+    ? STARTTIME_ADMIN_MAX_PAST_MS
+    : STARTTIME_MAX_PAST_MS;
+  const maxFuture = isAdminAction
+    ? STARTTIME_ADMIN_MAX_FUTURE_MS
+    : STARTTIME_MAX_FUTURE_MS;
+
+  if (startTime < now - maxPast) {
+    throw new ConvexError(
+      isAdminAction
+        ? "startTime cannot be more than 1 year in the past"
+        : "startTime cannot be more than 1 minute in the past"
+    );
+  }
+
+  if (startTime > now + maxFuture) {
+    throw new ConvexError(
+      isAdminAction
+        ? "startTime cannot be more than 10 years in the future"
+        : "startTime cannot be more than 1 year in the future"
     );
   }
 }

--- a/convex/auctions/mutations/create.test.ts
+++ b/convex/auctions/mutations/create.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import * as auth from "../../lib/auth";
 import { updateCounter } from "../../admin_utils";
+import { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE } from "../../constants";
 import {
   createAuctionHandler,
   saveDraftHandler,
@@ -217,6 +218,62 @@ describe("Create Mutations", () => {
           durationDays: 366,
         })
       ).rejects.toThrow("Invalid duration");
+    });
+
+    it("should reject startTime 2 min in the past for non-draft", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("u1");
+      mockCtx.db.get.mockResolvedValue({ _id: "cat1" });
+      const pastTime = Date.now() - 2 * MS_PER_MINUTE;
+      await expect(
+        createAuctionHandler(mockCtx as unknown as MutationCtx, {
+          ...validArgs,
+          isDraft: false,
+          startTime: pastTime,
+        })
+      ).rejects.toThrow("cannot be more than 1 minute in the past");
+    });
+
+    it("should reject startTime 2 years in the future for non-draft", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("u1");
+      mockCtx.db.get.mockResolvedValue({ _id: "cat1" });
+      const futureTime = Date.now() + 2 * 365 * MS_PER_DAY;
+      await expect(
+        createAuctionHandler(mockCtx as unknown as MutationCtx, {
+          ...validArgs,
+          isDraft: false,
+          startTime: futureTime,
+        })
+      ).rejects.toThrow("cannot be more than 1 year in the future");
+    });
+
+    it("should accept startTime 30 days in the future for non-draft", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("u1");
+      mockCtx.db.get.mockResolvedValue({ _id: "cat1" });
+      const futureTime = Date.now() + 30 * MS_PER_DAY;
+      const result = await createAuctionHandler(
+        mockCtx as unknown as MutationCtx,
+        {
+          ...validArgs,
+          isDraft: false,
+          startTime: futureTime,
+        }
+      );
+      expect(result).toBeDefined();
+    });
+
+    it("should allow past startTime for draft", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("u1");
+      mockCtx.db.get.mockResolvedValue({ _id: "cat1" });
+      const pastTime = Date.now() - MS_PER_HOUR;
+      const result = await createAuctionHandler(
+        mockCtx as unknown as MutationCtx,
+        {
+          ...validArgs,
+          isDraft: true,
+          startTime: pastTime,
+        }
+      );
+      expect(result).toBeDefined();
     });
   });
 
@@ -493,6 +550,30 @@ describe("Create Mutations", () => {
         "draft",
         1
       );
+    });
+
+    it("should reject startTime 2 min in the past on pending_review", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("u1");
+      mockCtx.db.get.mockResolvedValue({
+        _id: "a1",
+        sellerId: "u1",
+        status: "pending_review",
+        title: "Test Auction",
+        description: "Test Description",
+        startingPrice: 1000,
+        reservePrice: 2000,
+        images: { front: "img1" },
+      } as Doc<"auctions">);
+      const pastTime = Date.now() - 2 * MS_PER_MINUTE;
+      await expect(
+        saveDraftHandler(
+          mockCtx as unknown as MutationCtx,
+          {
+            auctionId: "a1" as Id<"auctions">,
+            startTime: pastTime,
+          } as PartialDraftArgs as SaveDraftArgs
+        )
+      ).rejects.toThrow("cannot be more than 1 minute in the past");
     });
   });
 

--- a/convex/auctions/mutations/create.ts
+++ b/convex/auctions/mutations/create.ts
@@ -14,6 +14,7 @@ import {
   assertEditable,
   type AuctionValidationInput,
 } from "./helpers";
+import { validateStartTimeBounds } from "../helpers";
 import {
   MAX_ADDITIONAL_IMAGES,
   AUCTION_MIN_DURATION_DAYS,
@@ -153,6 +154,10 @@ export const createAuctionHandler = async (
       images,
     };
     validateAuctionBeforePublish(validationInput);
+  }
+
+  if (startTime !== undefined && !isDraft) {
+    validateStartTimeBounds(startTime, false);
   }
 
   const auctionId = await ctx.db.insert("auctions", {
@@ -347,6 +352,9 @@ export const saveDraftHandler = async (
       patchData.durationDays = durationDays;
     }
     if (startTime !== undefined) {
+      if (existing.status !== "draft") {
+        validateStartTimeBounds(startTime, false);
+      }
       patchData.startTime = startTime;
     }
     if (restArgs.startingPrice !== undefined) {

--- a/convex/auctions/mutations/update.test.ts
+++ b/convex/auctions/mutations/update.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import * as auth from "../../lib/auth";
+import { MS_PER_DAY } from "../../constants";
 import {
   updateAuctionHandler,
   adminUpdateAuctionHandler,
@@ -355,6 +356,44 @@ describe("Update Mutations", () => {
         })
       ).rejects.toThrow("Auction not found");
     });
+
+    it("should reject startTime 2 years in the past for non-draft", async () => {
+      vi.mocked(auth.requireAdmin).mockResolvedValue({} as Doc<"profiles">);
+      mockCtx.db.get.mockResolvedValue({ _id: "a1", status: "pending_review" });
+      const pastTime = Date.now() - 2 * 365 * MS_PER_DAY;
+      await expect(
+        adminUpdateAuctionHandler(mockCtx as unknown as MutationCtx, {
+          auctionId: "a1" as Id<"auctions">,
+          updates: { startTime: pastTime },
+        })
+      ).rejects.toThrow("cannot be more than 1 year in the past");
+    });
+
+    it("should reject startTime 11 years in the future for non-draft", async () => {
+      vi.mocked(auth.requireAdmin).mockResolvedValue({} as Doc<"profiles">);
+      mockCtx.db.get.mockResolvedValue({ _id: "a1", status: "pending_review" });
+      const futureTime = Date.now() + 11 * 365 * MS_PER_DAY;
+      await expect(
+        adminUpdateAuctionHandler(mockCtx as unknown as MutationCtx, {
+          auctionId: "a1" as Id<"auctions">,
+          updates: { startTime: futureTime },
+        })
+      ).rejects.toThrow("cannot be more than 10 years in the future");
+    });
+
+    it("should accept startTime 5 years in the future for non-draft", async () => {
+      vi.mocked(auth.requireAdmin).mockResolvedValue({} as Doc<"profiles">);
+      mockCtx.db.get.mockResolvedValue({ _id: "a1", status: "pending_review" });
+      const futureTime = Date.now() + 5 * 365 * MS_PER_DAY;
+      const result = await adminUpdateAuctionHandler(
+        mockCtx as unknown as MutationCtx,
+        {
+          auctionId: "a1" as Id<"auctions">,
+          updates: { startTime: futureTime },
+        }
+      );
+      expect(result.success).toBe(true);
+    });
   });
 
   describe("bulkUpdateAuctionsHandler", () => {
@@ -399,6 +438,26 @@ describe("Update Mutations", () => {
           updates: { status: "active" },
         })
       ).rejects.toThrow("Bulk update exceeds limit");
+    });
+
+    it("should skip auctions with invalid startTime in bulk update", async () => {
+      vi.mocked(auth.requireAdmin).mockResolvedValue({} as Doc<"profiles">);
+      mockCtx.db.get.mockResolvedValue({
+        _id: "a1",
+        status: "pending_review",
+        title: "Test",
+        sellerId: "u1",
+      });
+      const pastTime = Date.now() - 2 * 365 * MS_PER_DAY;
+      const result = await bulkUpdateAuctionsHandler(
+        mockCtx as unknown as MutationCtx,
+        {
+          auctionIds: ["a1" as Id<"auctions">],
+          updates: { startTime: pastTime },
+        }
+      );
+      expect(result.skipped).toContain("a1");
+      expect(result.updated).not.toContain("a1");
     });
   });
 

--- a/convex/auctions/mutations/update.ts
+++ b/convex/auctions/mutations/update.ts
@@ -3,7 +3,7 @@ import { v, ConvexError } from "convex/values";
 import { mutation } from "../../_generated/server";
 import { requireAdmin, getAuthenticatedUserId } from "../../lib/auth";
 import { logAudit } from "../../admin_utils";
-import { validateAuctionStatus } from "../helpers";
+import { validateAuctionStatus, validateStartTimeBounds } from "../helpers";
 import {
   MAX_ADDITIONAL_IMAGES,
   AUCTION_MIN_DURATION_DAYS,
@@ -272,9 +272,7 @@ export const adminUpdateAuctionHandler = async (
       validateAuctionStatus(patched, newStatus);
     } catch (error) {
       if (error instanceof Error) {
-        throw new ConvexError(
-          `Cannot activate auction: ${error.message}`
-        );
+        throw new ConvexError(`Cannot activate auction: ${error.message}`);
       }
       throw error;
     }
@@ -305,6 +303,10 @@ export const adminUpdateAuctionHandler = async (
       args.updates.startingPrice < PRICE_THRESHOLD_FOR_INCREMENT
         ? SMALL_INCREMENT_AMOUNT
         : LARGE_INCREMENT_AMOUNT;
+  }
+
+  if (args.updates.startTime !== undefined && auction.status !== "draft") {
+    validateStartTimeBounds(args.updates.startTime, true);
   }
 
   await ctx.db.patch(args.auctionId, patchData);
@@ -433,6 +435,15 @@ export const bulkUpdateAuctionsHandler = async (
         newStatus !== "pending_review"
       ) {
         patchData.hiddenByFlags = false;
+      }
+
+      if (args.updates.startTime !== undefined && auction.status !== "draft") {
+        try {
+          validateStartTimeBounds(args.updates.startTime, true);
+        } catch {
+          skipped.push(id);
+          continue;
+        }
       }
 
       await ctx.db.patch(id, patchData);

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -44,6 +44,15 @@ export const AUCTION_FLAG_AUTO_HIDE_THRESHOLD = 3;
 // Maximum number of auctions that can be updated in a single bulk operation.
 export const MAX_BULK_UPDATE_SIZE = 50;
 
+/**
+ * startTime validation bounds for auction scheduling.
+ * Sellers have stricter limits than admins.
+ */
+export const STARTTIME_MAX_PAST_MS = MS_PER_MINUTE;
+export const STARTTIME_MAX_FUTURE_MS = 365 * MS_PER_DAY;
+export const STARTTIME_ADMIN_MAX_PAST_MS = 365 * MS_PER_DAY;
+export const STARTTIME_ADMIN_MAX_FUTURE_MS = 10 * 365 * MS_PER_DAY;
+
 // Duration before auction end that triggers a soft close (extension).
 export const SOFT_CLOSE_THRESHOLD_MS = 2 * MS_PER_MINUTE;
 


### PR DESCRIPTION
## Summary

- Add constants for startTime validation bounds (sellers: 1min past/1yr future, admins: 1yr past/10yr future)
- Add `validateStartTimeBounds` helper function in `convex/auctions/helpers.ts`
- Update `createAuction` and `saveDraft` mutations to validate startTime for non-draft auctions
- Update `adminUpdateAuction` and `bulkUpdateAuctions` mutations to validate startTime (bulk updates skip invalid auctions rather than failing)
- Add 9 new tests covering all validation scenarios

## Changes

| File | Description |
|------|-------------|
| `convex/constants.ts` | Add 4 new STARTTIME_*_MS constants |
| `convex/auctions/helpers.ts` | Add validateStartTimeBounds function |
| `convex/auctions/mutations/create.ts` | Add validation in createAuctionHandler and saveDraftHandler |
| `convex/auctions/mutations/update.ts` | Add validation in adminUpdateAuctionHandler and bulkUpdateAuctionsHandler |
| `convex/auctions/mutations/create.test.ts` | Add 5 tests |
| `convex/auctions/mutations/update.test.ts` | Add 4 tests |

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Add startTime bounds validation constants for sellers (1 minute past / 1 year future) and admins (1 year past / 10 years future) in `convex/constants.ts`
- Implement `validateStartTimeBounds()` helper in `convex/auctions/helpers.ts` to enforce scheduling constraints and throw ConvexError on invalid values
- Enforce startTime validation in `createAuction` and `saveDraft` mutations for non-draft auctions
- Enforce startTime validation in `adminUpdateAuction` and `bulkUpdateAuctions` mutations for non-draft auctions; bulk updates skip invalid auctions instead of failing the whole batch
- Add tests (9 total) covering seller vs admin bounds, draft vs non-draft behavior, and bulk-skip semantics
- Closes https://github.com/marcojsmith/AgriBid/issues/215

| Author | Lines Added | Lines Removed |
|--------|-------------:|--------------:|
| marcojsmith | 217 | 7 |

Breakdown by file:
- `convex/constants.ts`: +9
- `convex/auctions/helpers.ts`: +43 / -1
- `convex/auctions/mutations/create.ts`: +8
- `convex/auctions/mutations/create.test.ts`: +81
- `convex/auctions/mutations/update.ts`: +16 / -5
- `convex/auctions/mutations/update.test.ts`: +60 / -1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->