### PR TITLE
feat: add user settings persistence across sessions (Issue #118)

### DIFF
--- a/ISSUES_CHECKLIST.md
+++ b/ISSUES_CHECKLIST.md
@@ -29,7 +29,7 @@ Prioritized by size and quick wins for efficient resolution.
 - [ ] #171: (Linting) Enhance ESLint with stricter rules
   - _Description_: Upgrade ESLint configuration to use stricter TypeScript rules. **Status (2026-03-19)**: Unresolved. Enabling `strictTypeChecked` and `stylisticTypeChecked` currently yields 1,463 problems (593 errors, 870 warnings).
   - _Labels_: None
-- [ ] #118: Remember user settings
+- [x] #118: Remember user settings
   - _Description_: Implement persistence for user preferences/settings
   - _Labels_: None
 - [ ] #218: [Backend] Add location field to profiles table

--- a/codebase_notes.md
+++ b/codebase_notes.md
@@ -1,7 +1,8 @@
 # Development Notes
 
-## Current Status (2026-03-01)
+## Current Status (2026-03-30)
 
+- **User Preferences Storage**: Implemented persistent user preferences (Issue #118). The system stores view mode, sidebar state, filter defaults, bidding preferences, and notification settings in Convex database. Profile editing for bio, location, and companyName is now available.
 - **Proxy Bidding**: Fully implemented (backend & frontend). Auto-incrementing logic verified.
 - **Admin Portal**: Route-based refactor complete. KPIs and moderation flows are isolated to local route state.
 - **Performance**: Image caching, paginated queries, and context-based state management implemented.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -52,6 +52,7 @@ import type * as notifications from "../notifications.js";
 import type * as presence from "../presence.js";
 import type * as seed from "../seed.js";
 import type * as support from "../support.js";
+import type * as userPreferences from "../userPreferences.js";
 import type * as users from "../users.js";
 import type * as watchlist from "../watchlist.js";
 
@@ -106,6 +107,7 @@ declare const fullApi: ApiFromModules<{
   presence: typeof presence;
   seed: typeof seed;
   support: typeof support;
+  userPreferences: typeof userPreferences;
   users: typeof users;
   watchlist: typeof watchlist;
 }>;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -243,6 +243,36 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_updatedAt", ["updatedAt"]),
 
+  userPreferences: defineTable({
+    userId: v.string(),
+    viewMode: v.optional(v.union(v.literal("compact"), v.literal("detailed"))),
+    sidebarOpen: v.optional(v.boolean()),
+    defaultStatusFilter: v.optional(
+      v.union(v.literal("active"), v.literal("closed"), v.literal("all"))
+    ),
+    defaultMake: v.optional(v.string()),
+    defaultMinYear: v.optional(v.number()),
+    defaultMaxYear: v.optional(v.number()),
+    defaultMaxHours: v.optional(v.number()),
+    defaultMinPrice: v.optional(v.number()),
+    defaultMaxPrice: v.optional(v.number()),
+    biddingRequireConfirmation: v.optional(v.boolean()),
+    biddingProxyBidDefault: v.optional(v.boolean()),
+    notificationsBidOutbid: v.optional(v.boolean()),
+    notificationsWatchlistEnding: v.optional(
+      v.union(
+        v.literal("disabled"),
+        v.literal("1h"),
+        v.literal("3h"),
+        v.literal("24h")
+      )
+    ),
+    notificationsAuctionWon: v.optional(v.boolean()),
+    notificationsSellerAuctionApproved: v.optional(v.boolean()),
+    notificationsEmailEnabled: v.optional(v.boolean()),
+    updatedAt: v.number(),
+  }).index("by_userId", ["userId"]),
+
   counters: defineTable({
     name: v.string(), // e.g., "auctions", "profiles", "support", "announcements"
     total: v.number(),

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -1,0 +1,117 @@
+import { v } from "convex/values";
+
+import { query, mutation } from "./_generated/server";
+import { getAuthUser, resolveUserId, getAuthenticatedUserId } from "./lib/auth";
+
+/**
+ * Shared preference field validators used by both the full document validator
+ * and the mutation args to prevent drift.
+ */
+const preferenceFields = {
+  viewMode: v.optional(v.union(v.literal("compact"), v.literal("detailed"))),
+  sidebarOpen: v.optional(v.boolean()),
+  defaultStatusFilter: v.optional(
+    v.union(v.literal("active"), v.literal("closed"), v.literal("all"))
+  ),
+  defaultMake: v.optional(v.string()),
+  defaultMinYear: v.optional(v.number()),
+  defaultMaxYear: v.optional(v.number()),
+  defaultMaxHours: v.optional(v.number()),
+  defaultMinPrice: v.optional(v.number()),
+  defaultMaxPrice: v.optional(v.number()),
+  biddingRequireConfirmation: v.optional(v.boolean()),
+  biddingProxyBidDefault: v.optional(v.boolean()),
+  notificationsBidOutbid: v.optional(v.boolean()),
+  notificationsWatchlistEnding: v.optional(
+    v.union(
+      v.literal("disabled"),
+      v.literal("1h"),
+      v.literal("3h"),
+      v.literal("24h")
+    )
+  ),
+  notificationsAuctionWon: v.optional(v.boolean()),
+  notificationsSellerAuctionApproved: v.optional(v.boolean()),
+  notificationsEmailEnabled: v.optional(v.boolean()),
+};
+
+/**
+ * Validator for a full userPreferences document.
+ */
+export const UserPreferencesValidator = v.object({
+  _id: v.id("userPreferences"),
+  _creationTime: v.number(),
+  userId: v.string(),
+  ...preferenceFields,
+  updatedAt: v.number(),
+});
+
+/**
+ * Fetch the authenticated user's preferences.
+ * Returns null for unauthenticated users.
+ */
+export const getMyPreferences = query({
+  args: {},
+  returns: v.union(UserPreferencesValidator, v.null()),
+  handler: async (ctx) => {
+    const authUser = await getAuthUser(ctx);
+    if (!authUser) return null;
+    const userId = resolveUserId(authUser);
+    if (!userId) return null;
+
+    return await ctx.db
+      .query("userPreferences")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+  },
+});
+
+/**
+ * Upsert the authenticated user's preferences.
+ * All fields are optional — only provided fields are persisted.
+ */
+export const updateMyPreferences = mutation({
+  args: {
+    ...preferenceFields,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthenticatedUserId(ctx);
+    const now = Date.now();
+
+    const existing = await ctx.db
+      .query("userPreferences")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+
+    // Cross-field validation: compare incoming values against opposite bound
+    // from either args or existing preferences to prevent invalid ranges.
+    const minYear = args.defaultMinYear ?? existing?.defaultMinYear;
+    const maxYear = args.defaultMaxYear ?? existing?.defaultMaxYear;
+    if (minYear !== undefined && maxYear !== undefined && minYear > maxYear) {
+      throw new Error("defaultMinYear cannot be greater than defaultMaxYear");
+    }
+
+    const minPrice = args.defaultMinPrice ?? existing?.defaultMinPrice;
+    const maxPrice = args.defaultMaxPrice ?? existing?.defaultMaxPrice;
+    if (
+      minPrice !== undefined &&
+      maxPrice !== undefined &&
+      minPrice > maxPrice
+    ) {
+      throw new Error("defaultMinPrice cannot be greater than defaultMaxPrice");
+    }
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { ...args, updatedAt: now });
+    } else {
+      await ctx.db.insert("userPreferences", {
+        userId,
+        ...args,
+        updatedAt: now,
+      });
+    }
+
+    return null;
+  },
+});

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -12,6 +12,7 @@ import {
   getMyKYCDetailsHandler,
   deleteMyKYCDocumentHandler,
   findUserById,
+  updateMyProfileHandler,
 } from "./users";
 import * as auth from "./lib/auth";
 import * as adminUtils from "./admin_utils";
@@ -24,6 +25,7 @@ vi.mock("./lib/auth", () => ({
   requireAuth: vi.fn(),
   resolveUserId: vi.fn(),
   requireAdmin: vi.fn(),
+  getAuthenticatedUserId: vi.fn(),
 }));
 
 const mockAdminUser: AuthUser = {
@@ -894,6 +896,58 @@ describe("Users Coverage", () => {
       expect(result).toEqual({ success: true });
       expect(spy).toHaveBeenCalled();
       spy.mockRestore();
+    });
+  });
+
+  describe("updateMyProfileHandler", () => {
+    it("patches profile with provided fields", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("user123");
+      queryMock.unique.mockResolvedValue({ _id: "p1" as Id<"profiles"> });
+
+      const result = await updateMyProfileHandler(
+        mockCtx as unknown as MutationCtx,
+        { bio: "New bio", location: "Cape Town", companyName: "Farm Co" }
+      );
+
+      expect(result).toBeNull();
+      expect(mockCtx.db.patch).toHaveBeenCalledWith(
+        "p1",
+        expect.objectContaining({
+          bio: "New bio",
+          location: "Cape Town",
+          companyName: "Farm Co",
+        })
+      );
+    });
+
+    it("throws ConvexError when profile not found", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("user123");
+      queryMock.unique.mockResolvedValue(null);
+
+      await expect(
+        updateMyProfileHandler(mockCtx as unknown as MutationCtx, {
+          bio: "Bio",
+        })
+      ).rejects.toThrow(ConvexError);
+    });
+
+    it("patches with only provided fields (partial update)", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("user123");
+      queryMock.unique.mockResolvedValue({ _id: "p1" as Id<"profiles"> });
+
+      await updateMyProfileHandler(mockCtx as unknown as MutationCtx, {
+        location: "Pretoria",
+      });
+
+      expect(mockCtx.db.patch).toHaveBeenCalledWith(
+        "p1",
+        expect.objectContaining({ location: "Pretoria" })
+      );
+      const patchArgs = mockCtx.db.patch.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(patchArgs.bio).toBeUndefined();
     });
   });
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -12,6 +12,7 @@ import {
   requireAuth,
   resolveUserId,
   requireAdmin,
+  getAuthenticatedUserId,
 } from "./lib/auth";
 import type { Id, Doc } from "./_generated/dataModel";
 import { components } from "./_generated/api";
@@ -45,6 +46,7 @@ export const ProfileValidator = v.object({
   bio: v.optional(v.string()),
   phoneNumber: v.optional(v.string()),
   companyName: v.optional(v.string()),
+  location: v.optional(v.string()),
   createdAt: v.number(),
   updatedAt: v.number(),
 });
@@ -703,4 +705,51 @@ export const deleteMyKYCDocument = mutation({
   args: { storageId: v.id("_storage") },
   returns: v.object({ success: v.boolean() }),
   handler: deleteMyKYCDocumentHandler,
+});
+
+/**
+ * Update the authenticated user's profile fields (bio, location, companyName).
+ * Throws ConvexError if no profile exists.
+ * @param ctx - Mutation context.
+ * @param args - Fields to update.
+ * @param args.bio
+ * @param args.location
+ * @param args.companyName
+ * @returns null on success.
+ */
+export const updateMyProfileHandler = async (
+  ctx: MutationCtx,
+  args: { bio?: string; location?: string; companyName?: string }
+): Promise<null> => {
+  const userId = await getAuthenticatedUserId(ctx);
+
+  const profile = await ctx.db
+    .query("profiles")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .unique();
+
+  if (!profile) {
+    throw new ConvexError("Profile not found");
+  }
+
+  await ctx.db.patch(profile._id, {
+    ...args,
+    updatedAt: Date.now(),
+  });
+
+  return null;
+};
+
+/**
+ * Update the authenticated user's profile fields (bio, location, companyName).
+ * Throws ConvexError if no profile exists.
+ */
+export const updateMyProfile = mutation({
+  args: {
+    bio: v.optional(v.string()),
+    location: v.optional(v.string()),
+    companyName: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: updateMyProfileHandler,
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const MyListings = lazy(() => import("./pages/dashboard/MyListings"));
 const KYC = lazy(() => import("./pages/KYC"));
 const Support = lazy(() => import("./pages/Support"));
 const Notifications = lazy(() => import("./pages/Notifications"));
+const Settings = lazy(() => import("./pages/Settings"));
 
 /**
  * Global loading fallback for lazy-loaded routes.
@@ -74,6 +75,7 @@ const PageLoader = () => (
  * - "/kyc" → KYC (protected, allowedRole="any")
  * - "/support" → Support (protected, allowedRole="any")
  * - "/notifications" → Notifications (protected, allowedRole="any")
+ * - "/settings" → Settings (protected, allowedRole="any")
  *
  * @returns The root JSX element containing the BrowserRouter, layout and route definitions
  */
@@ -278,6 +280,14 @@ function App() {
               element={
                 <RoleProtectedRoute allowedRole="any">
                   <Notifications />
+                </RoleProtectedRoute>
+              }
+            />
+            <Route
+              path="/settings"
+              element={
+                <RoleProtectedRoute allowedRole="any">
+                  <Settings />
                 </RoleProtectedRoute>
               }
             />

--- a/src/components/FilterSidebar.test.tsx
+++ b/src/components/FilterSidebar.test.tsx
@@ -1,13 +1,20 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { BrowserRouter } from "react-router-dom";
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
+
+import { useSession } from "@/lib/auth-client";
 
 import { FilterSidebar } from "./FilterSidebar";
 
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: vi.fn(() => ({ data: null })),
 }));
 
 type ReactComponentType = React.ComponentType<unknown>;
@@ -109,7 +116,11 @@ describe("FilterSidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = new URLSearchParams();
-    (useQuery as Mock).mockReturnValue(["John Deere", "Case IH"]);
+    (useSession as Mock).mockReturnValue({ data: null });
+    // First useQuery call is for getActiveMakes, second is for getMyPreferences (skipped when no session)
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(undefined);
   });
 
   const renderSidebar = (onClose?: () => void) => {
@@ -342,6 +353,428 @@ describe("FilterSidebar", () => {
     const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
     expect(calledWith.get("status")).toBe("closed");
   });
-  // requires more complex interaction if they are not mocked.
-  // We can at least try to trigger the onValueChange if we can find the right way.
+
+  describe("authenticated session", () => {
+    beforeEach(() => {
+      (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+      (useQuery as Mock)
+        .mockReturnValueOnce(["John Deere", "Case IH"])
+        .mockReturnValueOnce(null);
+    });
+
+    it("shows Save Defaults and Clear Defaults buttons when authenticated", () => {
+      renderSidebar();
+      expect(screen.getByText("Save Defaults")).toBeInTheDocument();
+      expect(screen.getByText("Clear Defaults")).toBeInTheDocument();
+    });
+
+    it("calls updateMyPreferences when Save Defaults is clicked", () => {
+      const mockMutate = vi.fn();
+      (useMutation as Mock).mockReturnValue(mockMutate);
+
+      mockSearchParams.set("make", "John Deere");
+      (useQuery as Mock).mockReset();
+      (useQuery as Mock)
+        .mockReturnValueOnce(["John Deere", "Case IH"])
+        .mockReturnValueOnce(null);
+
+      renderSidebar();
+      fireEvent.click(screen.getByText("Save Defaults"));
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultMake: "John Deere" })
+      );
+    });
+
+    it("calls updateMyPreferences with undefined fields when Clear Defaults is clicked", () => {
+      const mockMutate = vi.fn();
+      (useMutation as Mock).mockReturnValue(mockMutate);
+
+      renderSidebar();
+      fireEvent.click(screen.getByText("Clear Defaults"));
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultMake: undefined })
+      );
+    });
+  });
+
+  it("applies saved preferences to filters when no URL params present", async () => {
+    const savedPrefs = {
+      defaultMake: "Case IH",
+      defaultMinYear: 2020,
+      defaultStatusFilter: "closed",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"]) // activeMakes
+      .mockReturnValueOnce(savedPrefs); // getMyPreferences
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    // After prefs load, the make select should reflect Case IH
+    const makeSelect = screen.getByLabelText(/Manufacturer/i);
+    expect(makeSelect).toHaveTextContent("Case IH");
+  });
+
+  it("URL params take priority over saved preferences", async () => {
+    mockSearchParams.set("make", "John Deere");
+
+    const savedPrefs = {
+      defaultMake: "Case IH",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    const makeSelect = screen.getByLabelText(/Manufacturer/i);
+    expect(makeSelect).toHaveTextContent("John Deere");
+  });
+
+  it("applies saved defaultStatusFilter when no URL params", async () => {
+    const savedPrefs = {
+      defaultStatusFilter: "closed",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Auction Status/i)).toHaveTextContent(
+      "Closed Auctions"
+    );
+  });
+
+  it("applies saved defaultMinYear and defaultMaxYear when no URL params", async () => {
+    const savedPrefs = {
+      defaultMinYear: 2018,
+      defaultMaxYear: 2023,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Minimum year/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Maximum year/i)).toBeInTheDocument();
+  });
+
+  it("applies saved defaultMinPrice and defaultMaxPrice when no URL params", async () => {
+    const savedPrefs = {
+      defaultMinPrice: 50000,
+      defaultMaxPrice: 500000,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Minimum price/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Maximum price/i)).toBeInTheDocument();
+  });
+
+  it("applies saved defaultMaxHours when no URL params", async () => {
+    const savedPrefs = {
+      defaultMaxHours: 3500,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Max Operating Hours/i)).toBeInTheDocument();
+  });
+
+  it("URL params take priority over preferences in all filter fields", async () => {
+    mockSearchParams.set("status", "closed");
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2020");
+    mockSearchParams.set("maxYear", "2023");
+    mockSearchParams.set("minPrice", "100000");
+    mockSearchParams.set("maxPrice", "500000");
+    mockSearchParams.set("maxHours", "1000");
+
+    const prefs = {
+      defaultStatusFilter: "all",
+      defaultMake: "Case IH",
+      defaultMinYear: 2015,
+      defaultMaxYear: 2025,
+      defaultMinPrice: 50000,
+      defaultMaxPrice: 1000000,
+      defaultMaxHours: 5000,
+    };
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(prefs);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    // URL params should win — status select should show "closed"
+    expect(screen.getByLabelText(/Auction Status/i)).toHaveTextContent(
+      "Closed Auctions"
+    );
+
+    // Apply filters and verify URL param values are preserved (not overridden by prefs)
+    fireEvent.click(screen.getByText(/Apply Filters/i));
+    const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
+    expect(calledWith.get("make")).toBe("John Deere");
+    expect(calledWith.get("minYear")).toBe("2020");
+    expect(calledWith.get("maxYear")).toBe("2023");
+  });
+
+  it("calls updateMyPreferences with undefined when saveDefaults with empty fields", () => {
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultStatusFilter: "active",
+        defaultMake: undefined,
+        defaultMinYear: undefined,
+        defaultMaxYear: undefined,
+        defaultMinPrice: undefined,
+        defaultMaxPrice: undefined,
+        defaultMaxHours: undefined,
+      })
+    );
+  });
+
+  it("calls clearDefaults with all fields undefined", () => {
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+    fireEvent.click(screen.getByText("Clear Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      defaultStatusFilter: undefined,
+      defaultMake: undefined,
+      defaultMinYear: undefined,
+      defaultMaxYear: undefined,
+      defaultMinPrice: undefined,
+      defaultMaxPrice: undefined,
+      defaultMaxHours: undefined,
+    });
+  });
+
+  it("handles null values in preferences defaults", async () => {
+    const savedPrefs = {
+      defaultMake: null as unknown as string,
+      defaultMinYear: null,
+      defaultMaxYear: null,
+      defaultMinPrice: null,
+      defaultMaxPrice: null,
+      defaultMaxHours: null,
+      defaultStatusFilter: null as unknown as string,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Auction Status/i)).toBeInTheDocument();
+  });
+
+  it("handles partial preferences with some fields set", async () => {
+    const savedPrefs = {
+      defaultMake: "Case IH",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Manufacturer/i)).toBeInTheDocument();
+  });
+
+  it("shows Save Defaults button with current filters as defaults", async () => {
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2020");
+
+    const savedPrefs = {
+      defaultMake: undefined,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultMake: "John Deere",
+        defaultMinYear: 2020,
+      })
+    );
+  });
+
+  it("does not apply preferences when preferences is undefined", async () => {
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(undefined); // No preferences
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Auction Status/i)).toBeInTheDocument();
+  });
+
+  it("keeps URL params over preferences for all fields when both are present", async () => {
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2022");
+    mockSearchParams.set("maxYear", "2024");
+    mockSearchParams.set("minPrice", "100000");
+    mockSearchParams.set("maxPrice", "2000000");
+    mockSearchParams.set("maxHours", "5000");
+
+    const savedPrefs = {
+      defaultMake: "Case IH",
+      defaultMinYear: 2020,
+      defaultMaxYear: 2023,
+      defaultMinPrice: 50000,
+      defaultMaxPrice: 500000,
+      defaultMaxHours: 3500,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs)
+      .mockReturnValueOnce(undefined);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    const makeSelect = screen.getByLabelText(/Manufacturer/i);
+    expect(makeSelect).toHaveTextContent("John Deere");
+  });
+
+  it("saveDefaults passes undefined for all empty filter fields", () => {
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultStatusFilter: "active",
+        defaultMake: undefined,
+        defaultMinYear: undefined,
+        defaultMaxYear: undefined,
+        defaultMinPrice: undefined,
+        defaultMaxPrice: undefined,
+        defaultMaxHours: undefined,
+      })
+    );
+  });
+
+  it("clearFilters calls onClose when provided", () => {
+    const onClose = vi.fn();
+    mockSearchParams.set("make", "John Deere");
+    renderSidebar(onClose);
+
+    fireEvent.click(screen.getByText(/Reset/i));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("saveDefaults passes parsed values for non-empty filter fields", async () => {
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+
+    mockSearchParams.set("status", "closed");
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2020");
+    mockSearchParams.set("maxYear", "2024");
+    mockSearchParams.set("minPrice", "100000");
+    mockSearchParams.set("maxPrice", "2000000");
+    mockSearchParams.set("maxHours", "5000");
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultStatusFilter: "closed",
+        defaultMake: "John Deere",
+        defaultMinYear: 2020,
+        defaultMaxYear: 2024,
+        defaultMinPrice: 100000,
+        defaultMaxPrice: 2000000,
+        defaultMaxHours: 5000,
+      })
+    );
+  });
 });

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -1,8 +1,10 @@
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "convex/_generated/api";
 import { X, Filter, RotateCcw } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
-import { useState } from "react";
+import { useState, useRef, useLayoutEffect } from "react";
+
+import { useSession } from "@/lib/auth-client";
 
 import { Button } from "./ui/button";
 import {
@@ -46,11 +48,21 @@ interface LocalFilters {
 export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeMakes = useQuery(api.auctions.getActiveMakes) ?? [];
+  const { data: session } = useSession();
+  const preferences = useQuery(
+    api.userPreferences.getMyPreferences,
+    session ? {} : "skip"
+  );
+  const updateMyPreferences = useMutation(
+    api.userPreferences.updateMyPreferences
+  );
 
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: 30 }, (_, i) =>
     (currentYear - i).toString()
   );
+
+  const prefsAppliedRef = useRef<boolean | null>(null);
 
   // Local state for debounced inputs
   const [localFilters, setLocalFilters] = useState<LocalFilters>(() => ({
@@ -62,6 +74,44 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
     maxPrice: searchParams.get("maxPrice") ?? "",
     maxHours: searchParams.get("maxHours") ?? "",
   }));
+
+  // Apply saved preferences once when they arrive
+  useLayoutEffect(() => {
+    if (preferences && prefsAppliedRef.current == null) {
+      prefsAppliedRef.current = true;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLocalFilters((prev) => ({
+        status:
+          searchParams.get("status") !== null
+            ? prev.status
+            : (preferences.defaultStatusFilter ?? prev.status),
+        make:
+          searchParams.get("make") !== null
+            ? prev.make
+            : (preferences.defaultMake ?? prev.make),
+        minYear:
+          searchParams.get("minYear") !== null
+            ? prev.minYear
+            : (preferences.defaultMinYear?.toString() ?? prev.minYear),
+        maxYear:
+          searchParams.get("maxYear") !== null
+            ? prev.maxYear
+            : (preferences.defaultMaxYear?.toString() ?? prev.maxYear),
+        minPrice:
+          searchParams.get("minPrice") !== null
+            ? prev.minPrice
+            : (preferences.defaultMinPrice?.toString() ?? prev.minPrice),
+        maxPrice:
+          searchParams.get("maxPrice") !== null
+            ? prev.maxPrice
+            : (preferences.defaultMaxPrice?.toString() ?? prev.maxPrice),
+        maxHours:
+          searchParams.get("maxHours") !== null
+            ? prev.maxHours
+            : (preferences.defaultMaxHours?.toString() ?? prev.maxHours),
+      }));
+    }
+  }, [preferences, searchParams]);
 
   const updateParam = (key: keyof LocalFilters, value: string) => {
     setLocalFilters((prev) => ({ ...prev, [key]: value }));
@@ -86,6 +136,47 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
     if (q) newParams.set("q", q);
     setSearchParams(newParams);
     if (onClose) onClose();
+  };
+
+  const saveDefaults = () => {
+    if (!session) return;
+    void updateMyPreferences({
+      defaultStatusFilter:
+        localFilters.status === "active" ||
+        localFilters.status === "closed" ||
+        localFilters.status === "all"
+          ? (localFilters.status as "active" | "closed" | "all")
+          : undefined,
+      defaultMake: localFilters.make || undefined,
+      defaultMinYear: localFilters.minYear
+        ? parseInt(localFilters.minYear, 10)
+        : undefined,
+      defaultMaxYear: localFilters.maxYear
+        ? parseInt(localFilters.maxYear, 10)
+        : undefined,
+      defaultMinPrice: localFilters.minPrice
+        ? parseInt(localFilters.minPrice, 10)
+        : undefined,
+      defaultMaxPrice: localFilters.maxPrice
+        ? parseInt(localFilters.maxPrice, 10)
+        : undefined,
+      defaultMaxHours: localFilters.maxHours
+        ? parseInt(localFilters.maxHours, 10)
+        : undefined,
+    });
+  };
+
+  const clearDefaults = () => {
+    if (!session) return;
+    void updateMyPreferences({
+      defaultStatusFilter: undefined,
+      defaultMake: undefined,
+      defaultMinYear: undefined,
+      defaultMaxYear: undefined,
+      defaultMinPrice: undefined,
+      defaultMaxPrice: undefined,
+      defaultMaxHours: undefined,
+    });
   };
 
   const { status, ...otherFilters } = localFilters;
@@ -298,22 +389,42 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         </div>
       </div>
 
-      <div className="p-6 border-t bg-muted/10 grid grid-cols-2 gap-3">
-        <Button
-          variant="outline"
-          onClick={clearFilters}
-          className="h-12 rounded-xl font-black uppercase tracking-tight border-2 gap-2"
-          disabled={!hasFilters}
-        >
-          <RotateCcw className="h-4 w-4" />
-          Reset
-        </Button>
-        <Button
-          onClick={applyFilters}
-          className="h-12 rounded-xl font-black uppercase tracking-tight shadow-lg shadow-primary/20"
-        >
-          Apply Filters
-        </Button>
+      <div className="p-6 border-t bg-muted/10 space-y-3">
+        {session && (
+          <div className="grid grid-cols-2 gap-3">
+            <Button
+              variant="outline"
+              onClick={saveDefaults}
+              className="h-10 rounded-xl font-black uppercase tracking-tight border-2 text-xs"
+            >
+              Save Defaults
+            </Button>
+            <Button
+              variant="outline"
+              onClick={clearDefaults}
+              className="h-10 rounded-xl font-black uppercase tracking-tight border-2 text-xs"
+            >
+              Clear Defaults
+            </Button>
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-3">
+          <Button
+            variant="outline"
+            onClick={clearFilters}
+            className="h-12 rounded-xl font-black uppercase tracking-tight border-2 gap-2"
+            disabled={!hasFilters}
+          >
+            <RotateCcw className="h-4 w-4" />
+            Reset
+          </Button>
+          <Button
+            onClick={applyFilters}
+            className="h-12 rounded-xl font-black uppercase tracking-tight shadow-lg shadow-primary/20"
+          >
+            Apply Filters
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { BrowserRouter } from "react-router-dom";
-import { useMutation } from "convex/react";
+import * as convexReact from "convex/react";
 
 import { useSession } from "@/lib/auth-client";
 
@@ -11,7 +11,6 @@ function typedMutationMock<T>(_val: unknown): T {
   return _val as T;
 }
 
-// Mock Header and Footer to isolate Layout testing
 vi.mock("./header/Header", () => ({
   Header: () => <header data-testid="mock-header">Header</header>,
 }));
@@ -20,9 +19,10 @@ vi.mock("./Footer", () => ({
   Footer: () => <footer data-testid="mock-footer">Footer</footer>,
 }));
 
-// Mock Convex hooks for NotificationListener inside Layout
 vi.mock("convex/react", () => ({
-  useQuery: vi.fn(() => []),
+  useQuery: vi.fn(() => {
+    return [];
+  }),
   useMutation: vi.fn(),
   Authenticated: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
@@ -32,26 +32,30 @@ vi.mock("convex/react", () => ({
   ),
 }));
 
-// Mock auth client for NotificationListener
 vi.mock("@/lib/auth-client", () => ({
   useSession: vi.fn(),
 }));
 
 describe("Layout", () => {
+  const mockUseQuery = convexReact.useQuery as ReturnType<typeof vi.fn>;
+  const mockUseMutation = convexReact.useMutation as ReturnType<typeof vi.fn>;
+  const mockUseSession = useSession as ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useSession).mockReturnValue({
+    mockUseSession.mockReturnValue({
       data: null,
       isPending: false,
     } as unknown as ReturnType<typeof useSession>);
-    vi.mocked(useMutation).mockReturnValue(
-      typedMutationMock<ReturnType<typeof useMutation>>(
+    mockUseMutation.mockReturnValue(
+      typedMutationMock<ReturnType<typeof convexReact.useMutation>>(
         vi.fn().mockResolvedValue({})
       )
     );
   });
 
   it("renders children and includes Header and Footer", () => {
+    mockUseQuery.mockReturnValue(undefined);
     render(
       <BrowserRouter>
         <Layout>
@@ -67,20 +71,21 @@ describe("Layout", () => {
 
   it("handles syncUser failure", async () => {
     const mockSyncUser = vi.fn().mockRejectedValue(new Error("Sync Fail"));
-    vi.mocked(useSession).mockReturnValue(
+    mockUseSession.mockReturnValue(
       typedMutationMock<ReturnType<typeof useSession>>({
         data: { user: { id: "user1" } },
         isPending: false,
       })
     );
-    vi.mocked(useMutation).mockReturnValue(
-      typedMutationMock<ReturnType<typeof useMutation>>(
+    mockUseMutation.mockReturnValue(
+      typedMutationMock<ReturnType<typeof convexReact.useMutation>>(
         mockSyncUser.mockRejectedValue(new Error("Sync Fail"))
       )
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+    mockUseQuery.mockReturnValue(undefined);
     render(
       <BrowserRouter>
         <Layout>

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
 
 import { useSession } from "@/lib/auth-client";
 
@@ -10,6 +10,7 @@ import Home from "./Home";
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(),
   usePaginatedQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -410,6 +411,96 @@ describe("Home Page Full Coverage", () => {
     (useQuery as Mock).mockReturnValue(undefined);
     renderHome();
     expect(screen.getAllByTestId("auction-card")).toHaveLength(2);
+  });
+
+  it("applies saved viewMode preference on load", async () => {
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    // First useQuery call → preferences, second → watchedAuctionIds
+    (useQuery as Mock)
+      .mockReturnValueOnce({ viewMode: "compact", sidebarOpen: false })
+      .mockReturnValueOnce(["1"]);
+
+    renderHome();
+
+    await act(async () => {});
+
+    expect(screen.getByText(/Auction 1 \(compact\)/i)).toBeInTheDocument();
+  });
+
+  it("applies saved sidebarOpen preference on load", async () => {
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock)
+      .mockReturnValueOnce({ viewMode: "detailed", sidebarOpen: true })
+      .mockReturnValueOnce(["1"]);
+
+    renderHome();
+
+    await act(async () => {});
+
+    expect(screen.getByText(/Hide Filters/i)).toBeInTheDocument();
+  });
+
+  it("fires updateMyPreferences when authenticated user toggles view mode", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByText(/Compact/i));
+
+    expect(mockMutate).toHaveBeenCalledWith({ viewMode: "compact" });
+  });
+
+  it("fires updateMyPreferences when authenticated user toggles sidebar", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByText(/Show Filters/i));
+
+    expect(mockMutate).toHaveBeenCalledWith({ sidebarOpen: true });
+  });
+
+  it("does not fire updateMyPreferences when unauthenticated user toggles view mode", () => {
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: null, isPending: false });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByText(/Compact/i));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("fires updateMyPreferences when authenticated user clicks Detailed", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByRole("button", { name: "Detailed" }));
+
+    expect(mockMutate).toHaveBeenCalledWith({ viewMode: "detailed" });
   });
 
   it("applies compact grid classes in loading state", () => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 // app/src/pages/Home.tsx
-import { useState } from "react";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useState, useRef, useLayoutEffect } from "react";
+import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
 import { api } from "convex/_generated/api";
 import { Link, useSearchParams } from "react-router-dom";
 import { SlidersHorizontal, ChevronDown } from "lucide-react";
@@ -34,9 +34,18 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
  * @returns The JSX element for the Home page
  */
 export default function Home() {
-  const { isPending } = useSession();
+  const { data: session, isPending } = useSession();
   const [searchParams] = useSearchParams();
   const isMobile = useMediaQuery("(max-width: 768px)");
+
+  const preferences = useQuery(
+    api.userPreferences.getMyPreferences,
+    session ? {} : "skip"
+  );
+  const updateMyPreferences = useMutation(
+    api.userPreferences.updateMyPreferences
+  );
+
   const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
   const [isDesktopSidebarOpen, setIsDesktopSidebarOpen] = useState(false);
 
@@ -44,6 +53,22 @@ export default function Home() {
   const [manualViewMode, setManualViewMode] = useState<
     "compact" | "detailed" | null
   >(null);
+  const prefsAppliedRef = useRef<boolean | null>(null);
+
+  // Apply saved preferences once when they arrive
+  useLayoutEffect(() => {
+    if (preferences !== undefined && prefsAppliedRef.current == null) {
+      prefsAppliedRef.current = true;
+      if (preferences?.viewMode != null) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setManualViewMode(preferences.viewMode);
+      }
+      if (preferences?.sidebarOpen != null) {
+         
+        setIsDesktopSidebarOpen(preferences.sidebarOpen);
+      }
+    }
+  }, [preferences]);
 
   // Derive viewMode from isMobile, but respect manual override
   const viewMode = manualViewMode ?? (isMobile ? "compact" : "detailed");
@@ -223,7 +248,9 @@ export default function Home() {
               <Button
                 variant={isDesktopSidebarOpen ? "default" : "outline"}
                 onClick={() => {
-                  setIsDesktopSidebarOpen(!isDesktopSidebarOpen);
+                  const next = !isDesktopSidebarOpen;
+                  setIsDesktopSidebarOpen(next);
+                  if (session) void updateMyPreferences({ sidebarOpen: next });
                 }}
                 className="hidden lg:flex h-10 px-4 rounded-xl border-2 gap-2 font-bold uppercase text-xs"
               >
@@ -238,6 +265,8 @@ export default function Home() {
                   size="sm"
                   onClick={() => {
                     setManualViewMode("detailed");
+                    if (session)
+                      void updateMyPreferences({ viewMode: "detailed" });
                   }}
                   className="h-8 px-3 rounded-lg text-[10px] font-black uppercase"
                 >
@@ -248,6 +277,8 @@ export default function Home() {
                   size="sm"
                   onClick={() => {
                     setManualViewMode("compact");
+                    if (session)
+                      void updateMyPreferences({ viewMode: "compact" });
                   }}
                   className="h-8 px-3 rounded-lg text-[10px] font-black uppercase"
                 >

--- a/src/pages/Profile.test.tsx
+++ b/src/pages/Profile.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
 
 import Profile from "./Profile";
 
@@ -15,6 +15,7 @@ interface AuctionCardProps {
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(),
   usePaginatedQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
 }));
 
 const { mockApi } = vi.hoisted(() => ({
@@ -275,6 +276,342 @@ describe("Profile Page", () => {
     renderProfile();
     expect(
       screen.queryByText(/Lichtenburg, North West Province/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Edit button only for profile owner", () => {
+    renderProfile("user1");
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it("does not show Edit button for non-owner", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile)
+        return { userId: "other", _id: "other" };
+      if (apiPath === mockApi.auctions.getSellerInfo) return mockSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+    renderProfile("user1");
+    expect(
+      screen.queryByRole("button", { name: /edit/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens edit form when Edit button is clicked", () => {
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/location/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/company name/i)).toBeInTheDocument();
+  });
+
+  it("cancels editing and restores view mode", () => {
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByLabelText(/bio/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it("calls updateMyProfile and closes form on save", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    fireEvent.change(screen.getByLabelText(/bio/i), {
+      target: { value: "New bio text" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ bio: "New bio text" })
+    );
+    expect(screen.queryByLabelText(/bio/i)).not.toBeInTheDocument();
+  });
+
+  it("shows Saving... while mutation is in-flight", async () => {
+    let resolvePromise: () => void;
+    const pendingPromise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+    (useMutation as Mock).mockReturnValue(() => pendingPromise);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    // Click save — mutation is pending
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    expect(screen.getByText("Saving...")).toBeInTheDocument();
+
+    // Resolve the mutation
+    await act(async () => {
+      resolvePromise!();
+    });
+
+    expect(screen.queryByText("Saving...")).not.toBeInTheDocument();
+  });
+
+  it("submits undefined for empty trimmed fields", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    // Leave all fields empty
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      bio: undefined,
+      location: undefined,
+      companyName: undefined,
+    });
+  });
+
+  it("logs error and stays in edit mode when save fails", async () => {
+    const mockMutate = vi.fn().mockRejectedValue(new Error("Network error"));
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(spy).toHaveBeenCalled();
+    // Edit form should still be open after failure
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it("updates location and companyName fields in edit form", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    fireEvent.change(screen.getByLabelText(/location/i), {
+      target: { value: "Durban, KZN" },
+    });
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: "Sunrise Farms" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "Durban, KZN",
+        companyName: "Sunrise Farms",
+      })
+    );
+  });
+
+  it("shows admin activity item when user has admin role", () => {
+    const adminSellerInfo = {
+      ...mockSellerInfo,
+      name: "Admin User",
+      role: "admin",
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return adminSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds)
+        return ["auction1"];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Admin role assigned")).toBeInTheDocument();
+  });
+
+  it("handles single-word name for getInitials", () => {
+    const shortNameSellerInfo = {
+      ...mockSellerInfo,
+      name: "Bob",
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return shortNameSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds)
+        return ["auction1"];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows verification requested activity for non-admin user", () => {
+    renderProfile("user1");
+
+    expect(screen.getByText("Verification requested")).toBeInTheDocument();
+  });
+
+  it("shows Complete Verification button for unverified owner", () => {
+    const unverifiedSellerInfo = {
+      ...mockSellerInfo,
+      isVerified: false,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return unverifiedSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(
+      screen.getByRole("button", { name: /complete verification/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+  });
+
+  it("shows — for Avg Sale when avgSalePrice is undefined", () => {
+    const noAvgSellerInfo = {
+      ...mockSellerInfo,
+      avgSalePrice: undefined,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return noAvgSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Avg Sale")).toBeInTheDocument();
+  });
+
+  it("renders ?? initials when name is undefined", () => {
+    const noNameSellerInfo = {
+      ...mockSellerInfo,
+      name: undefined,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return noNameSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("??")).toBeInTheDocument();
+  });
+
+  it("shows Unknown date for activity when createdAt is undefined", () => {
+    const noDateSellerInfo = {
+      ...mockSellerInfo,
+      createdAt: undefined,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return noDateSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows unverified badge for unverified seller", () => {
+    const unverifiedSellerInfo = {
+      ...mockSellerInfo,
+      isVerified: false,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return unverifiedSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+  });
+
+  it("shows Admin badge for admin role", () => {
+    const adminSellerInfo = {
+      ...mockSellerInfo,
+      role: "admin",
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return adminSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+
+  it("does not show Complete Verification button for verified owner", () => {
+    renderProfile("user1");
+
+    expect(
+      screen.queryByRole("button", { name: /complete verification/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders loading indicator during LoadingMore pagination", () => {
+    (usePaginatedQuery as Mock).mockReturnValue({
+      results: mockListings,
+      status: "LoadingMore",
+      loadMore: vi.fn(),
+    });
+
+    renderProfile();
+
+    const loadingElements = screen.getAllByText("Loading...");
+    expect(loadingElements.length).toBeGreaterThan(0);
+  });
+
+  it("does not show Complete Verification button for non-owner", () => {
+    const unverifiedSellerInfo = {
+      ...mockSellerInfo,
+      isVerified: false,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile)
+        return { ...mockMyProfile, userId: "other", _id: "other" };
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return unverifiedSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(
+      screen.queryByRole("button", { name: /complete verification/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from "react-router-dom";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
 import { api } from "convex/_generated/api";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -20,7 +20,12 @@ import {
   Mail,
   CreditCard,
   FileText,
+  Pencil,
+  X,
+  Check,
+  Building2,
 } from "lucide-react";
+import { useState } from "react";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -28,6 +33,8 @@ import { LoadingIndicator } from "@/components/LoadingIndicator";
 import { ProfileSkeleton } from "@/components/ProfileSkeleton";
 import { Button } from "@/components/ui/button";
 import { AuctionCard } from "@/components/auction/AuctionCard";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 
 interface ActivityItem {
   id: string;
@@ -166,6 +173,31 @@ export default function Profile() {
     !isProfileLoading &&
     (myProfile?.userId === userId || myProfile?._id === userId);
 
+  const updateMyProfile = useMutation(api.users.updateMyProfile);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [editForm, setEditForm] = useState({
+    bio: myProfile?.profile?.bio ?? "",
+    location: myProfile?.profile?.location ?? "",
+    companyName: myProfile?.profile?.companyName ?? "",
+  });
+
+  const handleSaveProfile = async () => {
+    setIsSaving(true);
+    try {
+      await updateMyProfile({
+        bio: editForm.bio || undefined,
+        location: editForm.location || undefined,
+        companyName: editForm.companyName || undefined,
+      });
+      setIsEditing(false);
+    } catch (error) {
+      console.error("Failed to save profile:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const sellerInfo = useQuery(api.auctions.getSellerInfo, {
     sellerId: userId ?? "",
   });
@@ -229,9 +261,29 @@ export default function Profile() {
                 </div>
               </div>
 
-              <h1 className="text-2xl font-black text-primary uppercase leading-none mb-2">
-                {sellerInfo.name}
-              </h1>
+              <div className="flex items-start justify-between">
+                <h1 className="text-2xl font-black text-primary uppercase leading-none mb-2">
+                  {sellerInfo.name}
+                </h1>
+                {isOwner && !isEditing && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setEditForm({
+                        bio: myProfile?.profile?.bio ?? "",
+                        location: myProfile?.profile?.location ?? "",
+                        companyName: myProfile?.profile?.companyName ?? "",
+                      });
+                      setIsEditing(true);
+                    }}
+                    className="h-8 px-2 rounded-md font-bold uppercase text-xs"
+                  >
+                    <Pencil className="h-3 w-3 mr-1" />
+                    Edit
+                  </Button>
+                )}
+              </div>
 
               <div className="flex flex-wrap gap-2 mb-3">
                 {sellerInfo.role === "admin" && (
@@ -257,20 +309,122 @@ export default function Profile() {
                 Member since {formatMemberSince(sellerInfo.createdAt)}
               </p>
 
-              {sellerInfo.bio && (
+              {isEditing ? (
+                <div className="space-y-3">
+                  <div>
+                    <label
+                      htmlFor="profile-bio"
+                      className="text-[10px] font-black uppercase text-muted-foreground tracking-widest"
+                    >
+                      Bio
+                    </label>
+                    <Textarea
+                      id="profile-bio"
+                      value={editForm.bio}
+                      onChange={(e) =>
+                        setEditForm({ ...editForm, bio: e.target.value })
+                      }
+                      placeholder="Tell us about yourself..."
+                      className="mt-1 min-h-[80px] rounded-xl border-2 font-bold text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="profile-location"
+                      className="text-[10px] font-black uppercase text-muted-foreground tracking-widest"
+                    >
+                      Location
+                    </label>
+                    <Input
+                      id="profile-location"
+                      value={editForm.location}
+                      onChange={(e) =>
+                        setEditForm({ ...editForm, location: e.target.value })
+                      }
+                      placeholder="City, Province"
+                      className="mt-1 rounded-xl border-2 font-bold text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="profile-company-name"
+                      className="text-[10px] font-black uppercase text-muted-foreground tracking-widest"
+                    >
+                      Company Name
+                    </label>
+                    <Input
+                      id="profile-company-name"
+                      value={editForm.companyName}
+                      onChange={(e) =>
+                        setEditForm({
+                          ...editForm,
+                          companyName: e.target.value,
+                        })
+                      }
+                      placeholder="Your company name"
+                      className="mt-1 rounded-xl border-2 font-bold text-sm"
+                    />
+                  </div>
+                  <div className="flex gap-2 pt-2">
+                    <Button
+                      onClick={handleSaveProfile}
+                      disabled={isSaving}
+                      className="flex-1 h-9 rounded-xl font-black uppercase text-xs"
+                    >
+                      {isSaving ? (
+                        <>
+                          <span className="animate-pulse">Saving...</span>
+                        </>
+                      ) : (
+                        <>
+                          <Check className="h-3 w-3 mr-1" />
+                          Save
+                        </>
+                      )}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        setEditForm({
+                          bio: myProfile?.profile?.bio ?? "",
+                          location: myProfile?.profile?.location ?? "",
+                          companyName: myProfile?.profile?.companyName ?? "",
+                        });
+                        setIsEditing(false);
+                      }}
+                      disabled={isSaving}
+                      className="flex-1 h-9 rounded-xl font-black uppercase text-xs border-2"
+                    >
+                      <X className="h-3 w-3 mr-1" />
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
                 <>
-                  <div className="h-px bg-border my-4" />
-                  <p className="text-sm text-muted-foreground leading-relaxed">
-                    {sellerInfo.bio}
-                  </p>
-                </>
-              )}
+                  {sellerInfo.bio && (
+                    <>
+                      <div className="h-px bg-border my-4" />
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {sellerInfo.bio}
+                      </p>
+                    </>
+                  )}
 
-              {sellerInfo.location && (
-                <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-3">
-                  <MapPin className="h-4 w-4" />
-                  {sellerInfo.location}
-                </p>
+                  {sellerInfo.location && (
+                    <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-3">
+                      <MapPin className="h-4 w-4" />
+                      {sellerInfo.location}
+                    </p>
+                  )}
+
+                  {sellerInfo.companyName && (
+                    <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-3">
+                      <Building2 className="h-4 w-4" />
+                      {sellerInfo.companyName}
+                    </p>
+                  )}
+                </>
               )}
             </CardContent>
 

--- a/src/pages/Settings.test.tsx
+++ b/src/pages/Settings.test.tsx
@@ -1,0 +1,324 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { useQuery, useMutation } from "convex/react";
+import React from "react";
+
+import { useSession } from "@/lib/auth-client";
+
+import Settings from "./Settings";
+
+vi.mock("convex/react", () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: vi.fn(() => ({ data: { user: { id: "u1" } } })),
+}));
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    userPreferences: {
+      getMyPreferences: { name: "userPreferences:getMyPreferences" },
+      updateMyPreferences: { name: "userPreferences:updateMyPreferences" },
+    },
+    users: {
+      getMyProfile: { name: "users:getMyProfile" },
+    },
+  },
+}));
+
+vi.mock("convex/_generated/api", () => ({ api: mockApi }));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <label className={className}>{children}</label>,
+}));
+
+vi.mock("@/components/ui/select", () => {
+  interface MockProps {
+    children: React.ReactNode;
+    onValueChange?: (v: string) => void;
+    value?: string;
+  }
+  return {
+    Select: ({ children, onValueChange }: MockProps) => (
+      <div>
+        {Array.isArray(children)
+          ? children.map((child) =>
+              child?.props?.children
+                ? { ...child, props: { ...child.props, onValueChange } }
+                : child
+            )
+          : children}
+      </div>
+    ),
+    SelectTrigger: ({ children }: MockProps) => <div>{children}</div>,
+    SelectValue: () => <span />,
+    SelectContent: ({
+      children,
+      onValueChange,
+    }: MockProps & { onValueChange?: (v: string) => void }) => (
+      <div>
+        {Array.isArray(children)
+          ? children.map(
+              (
+                child: React.ReactElement<{
+                  value: string;
+                  onClick?: () => void;
+                }>
+              ) =>
+                React.isValidElement(child)
+                  ? React.cloneElement(child, {
+                      onClick: () => onValueChange?.(child.props.value),
+                    })
+                  : child
+            )
+          : children}
+      </div>
+    ),
+    SelectItem: ({
+      children,
+      value,
+      onClick,
+    }: {
+      children: React.ReactNode;
+      value: string;
+      onClick?: () => void;
+    }) => (
+      <button data-testid={`select-item-${value}`} onClick={onClick}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+vi.mock("@/components/LoadingIndicator", () => ({
+  LoadingPage: ({ message }: { message: string }) => <div>{message}</div>,
+}));
+
+describe("Settings Page", () => {
+  const mockMutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences) return null;
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "buyer" } };
+      return null;
+    });
+  });
+
+  const renderSettings = () =>
+    render(
+      <BrowserRouter>
+        <Settings />
+      </BrowserRouter>
+    );
+
+  it("renders loading state when preferences are undefined", () => {
+    (useQuery as Mock).mockReturnValue(undefined);
+    renderSettings();
+    expect(screen.getByText("Loading settings...")).toBeInTheDocument();
+  });
+
+  it("renders all sections", () => {
+    renderSettings();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Display")).toBeInTheDocument();
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+  });
+
+  it("does not render seller-only section for non-sellers", () => {
+    renderSettings();
+    expect(
+      screen.queryByText("Auction Approval Notifications")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders seller-only section for sellers", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences) return null;
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "seller" } };
+      return null;
+    });
+    renderSettings();
+    expect(
+      screen.getByText("Auction Approval Notifications")
+    ).toBeInTheDocument();
+  });
+
+  it("toggles sidebar switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show Filter Sidebar by Default" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({ sidebarOpen: true });
+  });
+
+  it("toggles bid confirmation switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Require Bid Confirmation" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      biddingRequireConfirmation: true,
+    });
+  });
+
+  it("toggles proxy bid switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Enable Proxy Bidding by Default" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({ biddingProxyBidDefault: true });
+  });
+
+  it("toggles outbid alert switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(screen.getByRole("switch", { name: "Outbid Alerts" }));
+    expect(mockMutate).toHaveBeenCalledWith({ notificationsBidOutbid: false });
+  });
+
+  it("toggles auction won switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Auction Won Notifications" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({ notificationsAuctionWon: false });
+  });
+
+  it("toggles email notifications switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Email Notifications" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      notificationsEmailEnabled: true,
+    });
+  });
+
+  it("does not call mutation when session is null", () => {
+    (useSession as Mock).mockReturnValue({ data: null });
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show Filter Sidebar by Default" })
+    );
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("reflects saved preferences in switch aria-checked", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences)
+        return { sidebarOpen: true, biddingRequireConfirmation: true };
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "buyer" } };
+      return null;
+    });
+    renderSettings();
+    expect(
+      screen.getByRole("switch", { name: "Show Filter Sidebar by Default" })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("switch", { name: "Require Bid Confirmation" })
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles seller auction approval switch for sellers", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences) return null;
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "seller" } };
+      return null;
+    });
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Auction Approval Notifications" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      notificationsSellerAuctionApproved: false,
+    });
+  });
+
+  it("handles view mode change through select", () => {
+    renderSettings();
+    const selectItems = screen.getAllByTestId("select-item-detailed");
+    fireEvent.click(selectItems[0]);
+    expect(mockMutate).toHaveBeenCalledWith({ viewMode: "detailed" });
+  });
+
+  it("handles default status filter change through select", () => {
+    renderSettings();
+    const selectItems = screen.getAllByTestId("select-item-all");
+    fireEvent.click(selectItems[0]);
+    expect(mockMutate).toHaveBeenCalledWith({ defaultStatusFilter: "all" });
+  });
+
+  it("handles watchlist ending alerts change through select", () => {
+    renderSettings();
+    const selectItems = screen.getAllByTestId("select-item-24h");
+    fireEvent.click(selectItems[0]);
+    expect(mockMutate).toHaveBeenCalledWith({
+      notificationsWatchlistEnding: "24h",
+    });
+  });
+
+  it("renders all toggles in their non-default CSS state", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences)
+        return {
+          biddingProxyBidDefault: true,
+          notificationsBidOutbid: false,
+          notificationsAuctionWon: false,
+          notificationsSellerAuctionApproved: false,
+          notificationsEmailEnabled: true,
+        };
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "seller" } };
+      return null;
+    });
+    renderSettings();
+    expect(
+      screen.getByRole("switch", { name: "Enable Proxy Bidding by Default" })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("switch", { name: "Outbid Alerts" })
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("switch", { name: "Auction Won Notifications" })
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("switch", { name: "Auction Approval Notifications" })
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("switch", { name: "Email Notifications" })
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders with preferences set to null values", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences)
+        return {
+          viewMode: null,
+          sidebarOpen: null,
+          notificationsWatchlistEnding: null,
+        };
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "buyer" } };
+      return null;
+    });
+    renderSettings();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,271 @@
+import { useQuery, useMutation } from "convex/react";
+import { api } from "convex/_generated/api";
+
+import { useSession } from "@/lib/auth-client";
+import { LoadingPage } from "@/components/LoadingIndicator";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * Reusable toggle switch button.
+ *
+ * @param root0 - ToggleSwitch props.
+ * @param root0.label - Accessible label for the switch.
+ * @param root0.checked - Whether the switch is on.
+ * @param root0.onChange - Callback when the switch is toggled.
+ * @param root0.description - Optional description text below the label.
+ * @returns The toggle switch JSX element.
+ */
+function ToggleSwitch({
+  label,
+  checked,
+  onChange,
+  description,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+  description?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <Label className="text-sm font-bold">{label}</Label>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-label={label}
+        aria-checked={checked}
+        onClick={onChange}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${
+          checked ? "bg-primary" : "bg-input"
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
+            checked ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * User settings page for managing persistent preferences.
+ *
+ * Allows authenticated users to configure display, bidding, and notification preferences.
+ * Changes are persisted automatically to Convex on each interaction.
+ *
+ * @returns The settings page JSX element.
+ */
+export default function Settings() {
+  const { data: session } = useSession();
+  const preferences = useQuery(api.userPreferences.getMyPreferences, {});
+  const myProfile = useQuery(api.users.getMyProfile, {});
+  const updateMyPreferences = useMutation(
+    api.userPreferences.updateMyPreferences
+  );
+
+  if (preferences === undefined || myProfile === undefined) {
+    return <LoadingPage message="Loading settings..." />;
+  }
+
+  const isSeller = myProfile?.profile?.role === "seller";
+
+  const update = (fields: Parameters<typeof updateMyPreferences>[0]) => {
+    if (!session) return;
+    void updateMyPreferences(fields);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4 space-y-10">
+      <div>
+        <h1 className="text-3xl font-black uppercase tracking-tight text-primary">
+          Settings
+        </h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Your preferences are saved automatically.
+        </p>
+      </div>
+
+      {/* Display Preferences */}
+      <section className="space-y-6">
+        <h2 className="text-xs font-black uppercase tracking-widest text-muted-foreground border-b pb-2">
+          Display
+        </h2>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-bold">Default View Mode</Label>
+          <Select
+            value={preferences?.viewMode ?? "detailed"}
+            onValueChange={(value: "compact" | "detailed") =>
+              update({ viewMode: value })
+            }
+          >
+            <SelectTrigger className="w-48 h-10 rounded-xl border-2 font-bold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="detailed">Detailed</SelectItem>
+              <SelectItem value="compact">Compact</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <ToggleSwitch
+          label="Show Filter Sidebar by Default"
+          checked={preferences?.sidebarOpen ?? false}
+          onChange={() =>
+            update({ sidebarOpen: !(preferences?.sidebarOpen ?? false) })
+          }
+          description="Desktop only"
+        />
+
+        <div className="space-y-2">
+          <Label className="text-sm font-bold">Default Auction Status</Label>
+          <Select
+            value={preferences?.defaultStatusFilter ?? "active"}
+            onValueChange={(value: "active" | "closed" | "all") =>
+              update({ defaultStatusFilter: value })
+            }
+          >
+            <SelectTrigger className="w-48 h-10 rounded-xl border-2 font-bold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="active">Active Auctions</SelectItem>
+              <SelectItem value="closed">Closed Auctions</SelectItem>
+              <SelectItem value="all">All Auctions</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </section>
+
+      {/* Bidding Preferences */}
+      <section className="space-y-6">
+        <h2 className="text-xs font-black uppercase tracking-widest text-muted-foreground border-b pb-2">
+          Bidding
+        </h2>
+
+        <ToggleSwitch
+          label="Require Bid Confirmation"
+          checked={preferences?.biddingRequireConfirmation ?? false}
+          onChange={() =>
+            update({
+              biddingRequireConfirmation: !(
+                preferences?.biddingRequireConfirmation ?? false
+              ),
+            })
+          }
+          description="Show a confirmation dialog before placing bids"
+        />
+
+        <ToggleSwitch
+          label="Enable Proxy Bidding by Default"
+          checked={preferences?.biddingProxyBidDefault ?? false}
+          onChange={() =>
+            update({
+              biddingProxyBidDefault: !(
+                preferences?.biddingProxyBidDefault ?? false
+              ),
+            })
+          }
+          description="Automatically bid up to your maximum amount"
+        />
+      </section>
+
+      {/* Notification Preferences */}
+      <section className="space-y-6">
+        <h2 className="text-xs font-black uppercase tracking-widest text-muted-foreground border-b pb-2">
+          Notifications
+        </h2>
+        <p className="text-xs text-muted-foreground -mt-3">
+          These settings control which in-app notification types you receive.
+        </p>
+
+        <ToggleSwitch
+          label="Outbid Alerts"
+          checked={preferences?.notificationsBidOutbid ?? true}
+          onChange={() =>
+            update({
+              notificationsBidOutbid: !(
+                preferences?.notificationsBidOutbid ?? true
+              ),
+            })
+          }
+        />
+
+        <div className="space-y-2">
+          <Label className="text-sm font-bold">Watchlist Ending Alerts</Label>
+          <Select
+            value={preferences?.notificationsWatchlistEnding ?? "1h"}
+            onValueChange={(value: "disabled" | "1h" | "3h" | "24h") =>
+              update({ notificationsWatchlistEnding: value })
+            }
+          >
+            <SelectTrigger className="w-48 h-10 rounded-xl border-2 font-bold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="disabled">Disabled</SelectItem>
+              <SelectItem value="1h">1 hour before</SelectItem>
+              <SelectItem value="3h">3 hours before</SelectItem>
+              <SelectItem value="24h">24 hours before</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <ToggleSwitch
+          label="Auction Won Notifications"
+          checked={preferences?.notificationsAuctionWon ?? true}
+          onChange={() =>
+            update({
+              notificationsAuctionWon: !(
+                preferences?.notificationsAuctionWon ?? true
+              ),
+            })
+          }
+        />
+
+        {isSeller && (
+          <ToggleSwitch
+            label="Auction Approval Notifications"
+            checked={preferences?.notificationsSellerAuctionApproved ?? true}
+            onChange={() =>
+              update({
+                notificationsSellerAuctionApproved: !(
+                  preferences?.notificationsSellerAuctionApproved ?? true
+                ),
+              })
+            }
+            description="Notify when your auction listing is approved"
+          />
+        )}
+
+        <ToggleSwitch
+          label="Email Notifications"
+          checked={preferences?.notificationsEmailEnabled ?? false}
+          onChange={() =>
+            update({
+              notificationsEmailEnabled: !(
+                preferences?.notificationsEmailEnabled ?? false
+              ),
+            })
+          }
+          description="Receive notifications via email (in addition to in-app)"
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminFAQ.test.tsx
+++ b/src/pages/admin/AdminFAQ.test.tsx
@@ -74,6 +74,12 @@ const sampleFaqs: FaqItem[] = [
   },
 ];
 
+const threeFaqs: FaqItem[] = [
+  sampleFaqs[0],
+  sampleFaqs[1],
+  { ...sampleFaqs[0], _id: "faq3" as Id<"faqItems"> },
+];
+
 describe("AdminFAQ", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -212,5 +218,142 @@ describe("AdminFAQ", () => {
 
     expect(screen.getByText("Edit FAQ Item")).toBeInTheDocument();
     expect(screen.getByDisplayValue("How do I register?")).toBeInTheDocument();
+  });
+
+  it("move up button is disabled for first item", () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    render(<AdminFAQ />);
+
+    const moveUpButtons = screen.getAllByRole("button", { name: /move up/i });
+    expect(moveUpButtons[0]).toBeDisabled();
+  });
+
+  it("move down button is disabled for last item", () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled();
+  });
+
+  it("calls reorderFaqItems when move down is clicked", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockReorderFaqItems.mockResolvedValue(null);
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    fireEvent.click(moveDownButtons[0]);
+
+    await waitFor(() => {
+      expect(mockReorderFaqItems).toHaveBeenCalledWith({
+        orderedIds: ["faq2", "faq1"],
+      });
+    });
+  });
+
+  it("move up button enabled for non-first item", () => {
+    mockFaqItems = threeFaqs;
+    (useQuery as Mock).mockReturnValue(threeFaqs);
+    render(<AdminFAQ />);
+
+    const moveUpButtons = screen.getAllByRole("button", { name: /move up/i });
+    expect(moveUpButtons[1]).not.toBeDisabled();
+  });
+
+  it("move down button enabled for non-last item", () => {
+    mockFaqItems = threeFaqs;
+    (useQuery as Mock).mockReturnValue(threeFaqs);
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    expect(moveDownButtons[1]).not.toBeDisabled();
+  });
+
+  it("shows error toast when create fails", async () => {
+    mockFaqItems = [];
+    (useQuery as Mock).mockReturnValue([]);
+    mockCreateFaqItem.mockRejectedValue(new Error("Database error"));
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getByRole("button", { name: /new faq item/i }));
+    fireEvent.change(screen.getByLabelText(/question/i), {
+      target: { value: "Test Question" },
+    });
+    fireEvent.change(screen.getByLabelText(/answer/i), {
+      target: { value: "Test Answer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Database error");
+    });
+  });
+
+  it("shows error toast when toggle publish fails", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockUpdateFaqItem.mockRejectedValue(new Error("Update failed"));
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getByText("Published"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Update failed");
+    });
+  });
+
+  it("shows error toast when delete fails", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockDeleteFaqItem.mockRejectedValue(new Error("Delete failed"));
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Delete failed");
+    });
+  });
+
+  it("shows error toast when reorder fails", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockReorderFaqItems.mockRejectedValue(new Error("Reorder failed"));
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    fireEvent.click(moveDownButtons[0]);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Reorder failed");
+    });
+  });
+
+  it("shows error toast when save with empty answer", async () => {
+    mockFaqItems = [];
+    (useQuery as Mock).mockReturnValue([]);
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getByRole("button", { name: /new faq item/i }));
+    fireEvent.change(screen.getByLabelText(/question/i), {
+      target: { value: "Test Question" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Answer is required");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Implements user settings persistence (filters, preferences) across sessions via Convex backend
- Adds userPreferences Convex functions (save/get) with schema updates
- Updates FilterSidebar, Home, Profile, and new Settings page to read/write user preferences
- Adds comprehensive test coverage for all new and modified components

## Changes
- Backend: New convex/userPreferences.ts with savePreferences and getPreferences mutations/queries; schema additions for userPreferences table
- Frontend: FilterSidebar now restores saved filter state; Home page loads user prefs on mount; Profile page syncs settings; new dedicated Settings page at /settings
- Tests: Updated/added tests for FilterSidebar, Home, Profile, Settings, and Convex users module

## Related Issues
Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

### Features

- **User Settings Persistence**: Added persistent storage of user preferences across sessions via Convex backend (closes [#118](https://github.com/marcojsmith/AgriBid/issues/118))
  - Preferences now saved include: view mode (compact/detailed), sidebar state, default filters (status, make, year range, price range), auction operating hours, bid confirmation, proxy bidding defaults, and notification settings
  - Profile fields now include: `location` and `companyName` (in addition to existing `bio`)
  
- **Settings Page**: New dedicated `/settings` page for managing user preferences
  - Display preferences: view mode toggle, sidebar defaults, default auction status filter
  - Bidding preferences: bid confirmation requirement, proxy bidding defaults
  - Notification preferences: outbid alerts, watchlist ending alerts (disabled/1h/3h/24h), auction won alerts, email notifications
  - Seller-specific notification controls: auction approval alerts

- **Enhanced Existing Pages**:
  - **Home**: Now restores saved `viewMode` and `sidebarOpen` preferences on load; view mode and sidebar toggles persist changes
  - **Profile**: Profile editing now supports `location` and `companyName` fields; includes edit form with save/cancel flow
  - **FilterSidebar**: Now displays "Save Defaults" and "Clear Defaults" buttons for authenticated users; applies saved filter defaults while respecting URL query parameters (URL takes precedence)

### Improvements

- Convex schema expanded with `userPreferences` table storing per-user UI and notification settings with indexed lookups by `userId`
- Backend functions: `getMyPreferences` query and `updateMyPreferences` mutation with validation of numeric ranges (min/max year and price)
- Frontend preference hooks integrated throughout with session-based gating

### Testing

- Comprehensive test coverage added for FilterSidebar preference persistence and interaction
- Home page tests verify preference loading and mutation calls on view mode/sidebar changes
- Profile page tests cover edit form submission and error handling
- New Settings page test suite validates all preference toggles and selects
- Backend tests for `updateMyProfile` mutation with various field combinations
- Admin FAQ tests expanded for reorder UI and error handling

### Documentation

- Updated codebase status documentation reflecting Issue #118 completion
- Issue #118 marked as completed in checklist

## Contribution Summary

| Author | Lines Added | Lines Removed |
|--------|-------------|--------------|
| Marco Smith | 2224 | 60 |

### Related Issues

- Closes [#118](https://github.com/marcojsmith/AgriBid/issues/118): Remember user settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->