### PR TITLE
feat: add user settings persistence across sessions (Issue #118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,9 @@ Review this file for the current test coverage report or run `bun run test:cover
 When you come across this error, you need to reread the file and try again to apply the change. This is a safety mechanism to prevent you from making changes based on stale code context. Always read the entire file for full context before making any changes.
 
 ```text
-File C:\Users\marco\OneDrive\Documents\Projects\AgriBid\src\pages\Settings.tsx has been modified since it was last read.
-Last modification: 2026-03-31T07:13:11.162Z
-Last read: 2026-03-31T07:13:10.874Z
+File <file path> has been modified since it was last read.
+Last modification: <timestamp>
+Last read: <timestamp>
 Please read the file again before modifying it.
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ You are a senior full-stack developer assisting in building **AgriBid** — a re
 Test coverage is saved to `test-coverage/latest-coverage-output.txt` file.
 Review this file for the current test coverage report or run `bun run test:coverage` to update the file.
 
+## Coding harness
+
+When you come across this error, you need to reread the file and try again to apply the change. This is a safety mechanism to prevent you from making changes based on stale code context. Always read the entire file for full context before making any changes.
+
+```text
+File C:\Users\marco\OneDrive\Documents\Projects\AgriBid\src\pages\Settings.tsx has been modified since it was last read.
+Last modification: 2026-03-31T07:13:11.162Z
+Last read: 2026-03-31T07:13:10.874Z
+Please read the file again before modifying it.
+```
+
 ---
 
 # 2. Project Structure

--- a/ISSUES_CHECKLIST.md
+++ b/ISSUES_CHECKLIST.md
@@ -29,7 +29,7 @@ Prioritized by size and quick wins for efficient resolution.
 - [ ] #171: (Linting) Enhance ESLint with stricter rules
   - _Description_: Upgrade ESLint configuration to use stricter TypeScript rules. **Status (2026-03-19)**: Unresolved. Enabling `strictTypeChecked` and `stylisticTypeChecked` currently yields 1,463 problems (593 errors, 870 warnings).
   - _Labels_: None
-- [ ] #118: Remember user settings
+- [x] #118: Remember user settings
   - _Description_: Implement persistence for user preferences/settings
   - _Labels_: None
 - [ ] #218: [Backend] Add location field to profiles table

--- a/codebase_notes.md
+++ b/codebase_notes.md
@@ -1,7 +1,8 @@
 # Development Notes
 
-## Current Status (2026-03-01)
+## Current Status (2026-03-30)
 
+- **User Preferences Storage**: Implemented persistent user preferences (Issue #118). The system stores view mode, sidebar state, filter defaults, bidding preferences, and notification settings in Convex database. Profile editing for bio, location, and companyName is now available.
 - **Proxy Bidding**: Fully implemented (backend & frontend). Auto-incrementing logic verified.
 - **Admin Portal**: Route-based refactor complete. KPIs and moderation flows are isolated to local route state.
 - **Performance**: Image caching, paginated queries, and context-based state management implemented.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -52,6 +52,7 @@ import type * as notifications from "../notifications.js";
 import type * as presence from "../presence.js";
 import type * as seed from "../seed.js";
 import type * as support from "../support.js";
+import type * as userPreferences from "../userPreferences.js";
 import type * as users from "../users.js";
 import type * as watchlist from "../watchlist.js";
 
@@ -106,6 +107,7 @@ declare const fullApi: ApiFromModules<{
   presence: typeof presence;
   seed: typeof seed;
   support: typeof support;
+  userPreferences: typeof userPreferences;
   users: typeof users;
   watchlist: typeof watchlist;
 }>;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -243,6 +243,36 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_updatedAt", ["updatedAt"]),
 
+  userPreferences: defineTable({
+    userId: v.string(),
+    viewMode: v.optional(v.union(v.literal("compact"), v.literal("detailed"))),
+    sidebarOpen: v.optional(v.boolean()),
+    defaultStatusFilter: v.optional(
+      v.union(v.literal("active"), v.literal("closed"), v.literal("all"))
+    ),
+    defaultMake: v.optional(v.string()),
+    defaultMinYear: v.optional(v.number()),
+    defaultMaxYear: v.optional(v.number()),
+    defaultMaxHours: v.optional(v.number()),
+    defaultMinPrice: v.optional(v.number()),
+    defaultMaxPrice: v.optional(v.number()),
+    biddingRequireConfirmation: v.optional(v.boolean()),
+    biddingProxyBidDefault: v.optional(v.boolean()),
+    notificationsBidOutbid: v.optional(v.boolean()),
+    notificationsWatchlistEnding: v.optional(
+      v.union(
+        v.literal("disabled"),
+        v.literal("1h"),
+        v.literal("3h"),
+        v.literal("24h")
+      )
+    ),
+    notificationsAuctionWon: v.optional(v.boolean()),
+    notificationsSellerAuctionApproved: v.optional(v.boolean()),
+    notificationsEmailEnabled: v.optional(v.boolean()),
+    updatedAt: v.number(),
+  }).index("by_userId", ["userId"]),
+
   counters: defineTable({
     name: v.string(), // e.g., "auctions", "profiles", "support", "announcements"
     total: v.number(),

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -1,0 +1,121 @@
+import { v } from "convex/values";
+
+import { query, mutation } from "./_generated/server";
+import { getAuthUser, resolveUserId, getAuthenticatedUserId } from "./lib/auth";
+
+/**
+ * Shared preference field validators used by both the full document validator
+ * and the mutation args to prevent drift.
+ */
+const preferenceFields = {
+  viewMode: v.optional(v.union(v.literal("compact"), v.literal("detailed"))),
+  sidebarOpen: v.optional(v.boolean()),
+  defaultStatusFilter: v.optional(
+    v.union(v.literal("active"), v.literal("closed"), v.literal("all"))
+  ),
+  defaultMake: v.optional(v.string()),
+  defaultMinYear: v.optional(v.number()),
+  defaultMaxYear: v.optional(v.number()),
+  defaultMaxHours: v.optional(v.number()),
+  defaultMinPrice: v.optional(v.number()),
+  defaultMaxPrice: v.optional(v.number()),
+  biddingRequireConfirmation: v.optional(v.boolean()),
+  biddingProxyBidDefault: v.optional(v.boolean()),
+  notificationsBidOutbid: v.optional(v.boolean()),
+  notificationsWatchlistEnding: v.optional(
+    v.union(
+      v.literal("disabled"),
+      v.literal("1h"),
+      v.literal("3h"),
+      v.literal("24h")
+    )
+  ),
+  notificationsAuctionWon: v.optional(v.boolean()),
+  notificationsSellerAuctionApproved: v.optional(v.boolean()),
+  notificationsEmailEnabled: v.optional(v.boolean()),
+};
+
+/**
+ * Validator for the full userPreferences document.
+ * Used by server queries/mutations and for type-safe consumption in the frontend.
+ * Validates the complete shape of a userPreferences document, including system fields
+ * (_id, _creationTime, userId, updatedAt) and all user-configurable preference fields
+ * defined in preferenceFields.
+ */
+export const UserPreferencesValidator = v.object({
+  _id: v.id("userPreferences"),
+  _creationTime: v.number(),
+  userId: v.string(),
+  ...preferenceFields,
+  updatedAt: v.number(),
+});
+
+/**
+ * Fetch the authenticated user's preferences.
+ * Returns null for unauthenticated users.
+ */
+export const getMyPreferences = query({
+  args: {},
+  returns: v.union(UserPreferencesValidator, v.null()),
+  handler: async (ctx) => {
+    const authUser = await getAuthUser(ctx);
+    if (!authUser) return null;
+    const userId = resolveUserId(authUser);
+    if (!userId) return null;
+
+    return await ctx.db
+      .query("userPreferences")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+  },
+});
+
+/**
+ * Upsert the authenticated user's preferences.
+ * All fields are optional — only provided fields are persisted.
+ */
+export const updateMyPreferences = mutation({
+  args: {
+    ...preferenceFields,
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const userId = await getAuthenticatedUserId(ctx);
+    const now = Date.now();
+
+    const existing = await ctx.db
+      .query("userPreferences")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+
+    // Cross-field validation: compare incoming values against opposite bound
+    // from either args or existing preferences to prevent invalid ranges.
+    const minYear = args.defaultMinYear ?? existing?.defaultMinYear;
+    const maxYear = args.defaultMaxYear ?? existing?.defaultMaxYear;
+    if (minYear !== undefined && maxYear !== undefined && minYear > maxYear) {
+      throw new Error("defaultMinYear cannot be greater than defaultMaxYear");
+    }
+
+    const minPrice = args.defaultMinPrice ?? existing?.defaultMinPrice;
+    const maxPrice = args.defaultMaxPrice ?? existing?.defaultMaxPrice;
+    if (
+      minPrice !== undefined &&
+      maxPrice !== undefined &&
+      minPrice > maxPrice
+    ) {
+      throw new Error("defaultMinPrice cannot be greater than defaultMaxPrice");
+    }
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { ...args, updatedAt: now });
+    } else {
+      await ctx.db.insert("userPreferences", {
+        userId,
+        ...args,
+        updatedAt: now,
+      });
+    }
+
+    return null;
+  },
+});

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -12,6 +12,7 @@ import {
   getMyKYCDetailsHandler,
   deleteMyKYCDocumentHandler,
   findUserById,
+  updateMyProfileHandler,
 } from "./users";
 import * as auth from "./lib/auth";
 import * as adminUtils from "./admin_utils";
@@ -24,6 +25,7 @@ vi.mock("./lib/auth", () => ({
   requireAuth: vi.fn(),
   resolveUserId: vi.fn(),
   requireAdmin: vi.fn(),
+  getAuthenticatedUserId: vi.fn(),
 }));
 
 const mockAdminUser: AuthUser = {
@@ -894,6 +896,58 @@ describe("Users Coverage", () => {
       expect(result).toEqual({ success: true });
       expect(spy).toHaveBeenCalled();
       spy.mockRestore();
+    });
+  });
+
+  describe("updateMyProfileHandler", () => {
+    it("patches profile with provided fields", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("user123");
+      queryMock.unique.mockResolvedValue({ _id: "p1" as Id<"profiles"> });
+
+      const result = await updateMyProfileHandler(
+        mockCtx as unknown as MutationCtx,
+        { bio: "New bio", location: "Cape Town", companyName: "Farm Co" }
+      );
+
+      expect(result).toBeNull();
+      expect(mockCtx.db.patch).toHaveBeenCalledWith(
+        "p1",
+        expect.objectContaining({
+          bio: "New bio",
+          location: "Cape Town",
+          companyName: "Farm Co",
+        })
+      );
+    });
+
+    it("throws ConvexError when profile not found", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("user123");
+      queryMock.unique.mockResolvedValue(null);
+
+      await expect(
+        updateMyProfileHandler(mockCtx as unknown as MutationCtx, {
+          bio: "Bio",
+        })
+      ).rejects.toThrow(ConvexError);
+    });
+
+    it("patches with only provided fields (partial update)", async () => {
+      vi.mocked(auth.getAuthenticatedUserId).mockResolvedValue("user123");
+      queryMock.unique.mockResolvedValue({ _id: "p1" as Id<"profiles"> });
+
+      await updateMyProfileHandler(mockCtx as unknown as MutationCtx, {
+        location: "Pretoria",
+      });
+
+      expect(mockCtx.db.patch).toHaveBeenCalledWith(
+        "p1",
+        expect.objectContaining({ location: "Pretoria" })
+      );
+      const patchArgs = mockCtx.db.patch.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(patchArgs.bio).toBeUndefined();
     });
   });
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -12,6 +12,7 @@ import {
   requireAuth,
   resolveUserId,
   requireAdmin,
+  getAuthenticatedUserId,
 } from "./lib/auth";
 import type { Id, Doc } from "./_generated/dataModel";
 import { components } from "./_generated/api";
@@ -45,6 +46,7 @@ export const ProfileValidator = v.object({
   bio: v.optional(v.string()),
   phoneNumber: v.optional(v.string()),
   companyName: v.optional(v.string()),
+  location: v.optional(v.string()),
   createdAt: v.number(),
   updatedAt: v.number(),
 });
@@ -703,4 +705,51 @@ export const deleteMyKYCDocument = mutation({
   args: { storageId: v.id("_storage") },
   returns: v.object({ success: v.boolean() }),
   handler: deleteMyKYCDocumentHandler,
+});
+
+/**
+ * Update the authenticated user's profile fields (bio, location, companyName).
+ * Throws ConvexError if no profile exists.
+ * @param ctx - Mutation context.
+ * @param args - Fields to update.
+ * @param args.bio
+ * @param args.location
+ * @param args.companyName
+ * @returns null on success.
+ */
+export const updateMyProfileHandler = async (
+  ctx: MutationCtx,
+  args: { bio?: string; location?: string; companyName?: string }
+): Promise<null> => {
+  const userId = await getAuthenticatedUserId(ctx);
+
+  const profile = await ctx.db
+    .query("profiles")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .unique();
+
+  if (!profile) {
+    throw new ConvexError("Profile not found");
+  }
+
+  await ctx.db.patch(profile._id, {
+    ...args,
+    updatedAt: Date.now(),
+  });
+
+  return null;
+};
+
+/**
+ * Update the authenticated user's profile fields (bio, location, companyName).
+ * Throws ConvexError if no profile exists.
+ */
+export const updateMyProfile = mutation({
+  args: {
+    bio: v.optional(v.string()),
+    location: v.optional(v.string()),
+    companyName: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: updateMyProfileHandler,
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const MyListings = lazy(() => import("./pages/dashboard/MyListings"));
 const KYC = lazy(() => import("./pages/KYC"));
 const Support = lazy(() => import("./pages/Support"));
 const Notifications = lazy(() => import("./pages/Notifications"));
+const Settings = lazy(() => import("./pages/Settings"));
 
 /**
  * Global loading fallback for lazy-loaded routes.
@@ -74,6 +75,7 @@ const PageLoader = () => (
  * - "/kyc" → KYC (protected, allowedRole="any")
  * - "/support" → Support (protected, allowedRole="any")
  * - "/notifications" → Notifications (protected, allowedRole="any")
+ * - "/settings" → Settings (protected, allowedRole="any")
  *
  * @returns The root JSX element containing the BrowserRouter, layout and route definitions
  */
@@ -278,6 +280,14 @@ function App() {
               element={
                 <RoleProtectedRoute allowedRole="any">
                   <Notifications />
+                </RoleProtectedRoute>
+              }
+            />
+            <Route
+              path="/settings"
+              element={
+                <RoleProtectedRoute allowedRole="any">
+                  <Settings />
                 </RoleProtectedRoute>
               }
             />

--- a/src/components/AuctionCardSkeleton.tsx
+++ b/src/components/AuctionCardSkeleton.tsx
@@ -35,7 +35,7 @@ export const AuctionCardSkeleton = ({
           <div
             className={cn(
               "bg-muted relative overflow-hidden flex items-center justify-center",
-              isCompact ? "aspect-[4/3] h-full border-r" : "aspect-video"
+              isCompact ? "aspect-[4/3] border-r" : "aspect-video"
             )}
           >
             <span className={isCompact ? "text-2xl" : "text-4xl"}>🚜</span>

--- a/src/components/AuctionCardSkeleton.tsx
+++ b/src/components/AuctionCardSkeleton.tsx
@@ -34,15 +34,17 @@ export const AuctionCardSkeleton = ({
         >
           <div
             className={cn(
-              "bg-muted relative overflow-hidden",
-              isCompact ? "aspect-[4/3] border-r" : "aspect-video"
+              "bg-muted relative overflow-hidden flex items-center justify-center",
+              isCompact ? "aspect-[4/3] h-full border-r" : "aspect-video"
             )}
-          />
+          >
+            <span className={isCompact ? "text-2xl" : "text-4xl"}>🚜</span>
+          </div>
 
           {/* Timer area placeholder - Under Image (Compact) */}
           {isCompact && (
-            <div className="h-12 border-t border-r bg-muted/30 flex items-center justify-center px-4">
-              <div className="h-4 bg-muted rounded w-full" />
+            <div className="h-12 border-t border-r bg-muted/30 flex items-center justify-center">
+              <div className="h-5 bg-muted rounded w-16" />
             </div>
           )}
         </div>

--- a/src/components/FilterSidebar.test.tsx
+++ b/src/components/FilterSidebar.test.tsx
@@ -1,13 +1,20 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { BrowserRouter } from "react-router-dom";
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
+
+import { useSession } from "@/lib/auth-client";
 
 import { FilterSidebar } from "./FilterSidebar";
 
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: vi.fn(() => ({ data: null })),
 }));
 
 type ReactComponentType = React.ComponentType<unknown>;
@@ -109,7 +116,11 @@ describe("FilterSidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = new URLSearchParams();
-    (useQuery as Mock).mockReturnValue(["John Deere", "Case IH"]);
+    (useSession as Mock).mockReturnValue({ data: null });
+    // First useQuery call is for getActiveMakes, second is for getMyPreferences (skipped when no session)
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(undefined);
   });
 
   const renderSidebar = (onClose?: () => void) => {
@@ -125,7 +136,7 @@ describe("FilterSidebar", () => {
     const item = screen.getAllByTestId("select-item-2024")[0];
     fireEvent.click(item);
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
+    // Auto-apply: filters update immediately when changed
     const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
     expect(calledWith.get("minYear")).toBe("2024");
   });
@@ -137,50 +148,62 @@ describe("FilterSidebar", () => {
     const anyItem = screen.getAllByTestId("select-item-any")[0]; // minYear 'any'
     fireEvent.click(anyItem);
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
+    // Auto-apply: filters update immediately when changed
     const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
     expect(calledWith.has("minYear")).toBe(false);
   });
 
   it("updates maxYear and handles 'any' selection", () => {
+    mockSearchParams.set("maxYear", "2024");
     renderSidebar();
-    const item = screen.getAllByTestId("select-item-2022")[1]; // maxYear '2022'
-    fireEvent.click(item);
+    mockSetSearchParams.mockClear();
+
+    // Click 'any' to clear maxYear - auto-apply should remove it from URL
     fireEvent.click(screen.getAllByTestId("select-item-any")[1]); // maxYear 'any'
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
-    const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
-    expect(calledWith.has("maxYear")).toBe(false);
+    // Get the call after clicking 'any'
+    const calls = mockSetSearchParams.mock.calls;
+    const lastCall = calls[calls.length - 1][0] as URLSearchParams;
+    expect(lastCall.has("maxYear")).toBe(false);
   });
 
   it("updates minPrice and handles 'any' selection", () => {
+    mockSearchParams.set("minPrice", "100000");
     renderSidebar();
-    fireEvent.click(screen.getByTestId("select-item-100000"));
+    mockSetSearchParams.mockClear();
+
+    // Click 'any' to clear minPrice - auto-apply should remove it from URL
     fireEvent.click(screen.getAllByTestId("select-item-any")[2]); // minPrice 'any'
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
-    const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
-    expect(calledWith.has("minPrice")).toBe(false);
+    const calls = mockSetSearchParams.mock.calls;
+    const lastCall = calls[calls.length - 1][0] as URLSearchParams;
+    expect(lastCall.has("minPrice")).toBe(false);
   });
 
   it("updates maxPrice and handles 'any' selection", () => {
+    mockSearchParams.set("maxPrice", "500000");
     renderSidebar();
-    fireEvent.click(screen.getByTestId("select-item-5000000"));
+    mockSetSearchParams.mockClear();
+
+    // Click 'any' to clear maxPrice - auto-apply should remove it from URL
     fireEvent.click(screen.getAllByTestId("select-item-any")[3]); // maxPrice 'any'
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
-    const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
-    expect(calledWith.has("maxPrice")).toBe(false);
+    const calls = mockSetSearchParams.mock.calls;
+    const lastCall = calls[calls.length - 1][0] as URLSearchParams;
+    expect(lastCall.has("maxPrice")).toBe(false);
   });
 
   it("updates maxHours and handles 'any' selection", () => {
+    mockSearchParams.set("maxHours", "1000");
     renderSidebar();
-    fireEvent.click(screen.getByTestId("select-item-5000"));
+    mockSetSearchParams.mockClear();
+
+    // Click 'any' to clear maxHours - auto-apply should remove it from URL
     fireEvent.click(screen.getAllByTestId("select-item-any")[4]); // maxHours 'any'
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
-    const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
-    expect(calledWith.has("maxHours")).toBe(false);
+    const calls = mockSetSearchParams.mock.calls;
+    const lastCall = calls[calls.length - 1][0] as URLSearchParams;
+    expect(lastCall.has("maxHours")).toBe(false);
   });
 
   it("renders all filter sections", () => {
@@ -208,11 +231,14 @@ describe("FilterSidebar", () => {
     expect(screen.getByText("Closed Auctions")).toBeInTheDocument();
   });
 
-  it("applies filters when Apply button is clicked", () => {
+  it("applies filters when filter value changes (auto-apply)", () => {
     const onClose = vi.fn();
     renderSidebar(onClose);
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
+    // Change a filter - should auto-apply
+    fireEvent.change(screen.getByLabelText(/Manufacturer/i), {
+      target: { value: "John Deere" },
+    });
 
     expect(mockSetSearchParams).toHaveBeenCalled();
   });
@@ -221,7 +247,7 @@ describe("FilterSidebar", () => {
     mockSearchParams.set("minPrice", "5000");
     renderSidebar();
 
-    fireEvent.click(screen.getByText(/Reset/i));
+    fireEvent.click(screen.getByLabelText(/Reset filters/i));
 
     expect(mockSetSearchParams).toHaveBeenCalled();
     const calledWith = mockSetSearchParams.mock
@@ -247,24 +273,24 @@ describe("FilterSidebar", () => {
     expect(select).toHaveTextContent("John Deere");
   });
 
-  it("applyFilters deletes status if it is 'active'", () => {
+  it("filters auto-apply and delete status if it is 'active'", () => {
+    mockSearchParams.set("status", "active");
     renderSidebar();
-    fireEvent.click(screen.getByText(/Apply Filters/i));
 
+    // Auto-apply runs on mount: 'active' status should be stripped from URL params
     const calledWith = mockSetSearchParams.mock
       .calls[0]?.[0] as URLSearchParams;
+    expect(calledWith).toBeDefined();
     expect(calledWith.has("status")).toBe(false);
   });
 
-  it("applyFilters deletes empty values", () => {
+  it("filters auto-apply and delete empty values", () => {
     // Set an empty value in mockSearchParams
     mockSearchParams.set("make", "");
     mockSearchParams.set("minYear", "2020");
     renderSidebar();
 
-    // Click apply
-    fireEvent.click(screen.getByText(/Apply Filters/i));
-
+    // Auto-apply should filter out empty values
     const calledWith = mockSetSearchParams.mock
       .calls[0]?.[0] as URLSearchParams;
     // Empty values should be removed
@@ -273,12 +299,12 @@ describe("FilterSidebar", () => {
     expect(calledWith.get("minYear")).toBe("2020");
   });
 
-  it("clearFilters preserves search query 'q'", () => {
+  it("resetFilters preserves search query 'q'", () => {
     mockSearchParams.set("q", "tractor");
     mockSearchParams.set("make", "JD");
     renderSidebar();
 
-    fireEvent.click(screen.getByText(/Reset/i));
+    fireEvent.click(screen.getByLabelText(/Reset filters/i));
 
     const calledWith = mockSetSearchParams.mock
       .calls[0]?.[0] as URLSearchParams;
@@ -292,13 +318,17 @@ describe("FilterSidebar", () => {
     expect(resetButton).toBeDisabled();
   });
 
-  it("handles applyFilters and clearFilters without onClose callback", () => {
+  it("handles filter changes and reset without onClose callback", () => {
     renderSidebar();
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
+    // Filter change auto-applies
+    fireEvent.change(screen.getByLabelText(/Manufacturer/i), {
+      target: { value: "John Deere" },
+    });
     expect(mockSetSearchParams).toHaveBeenCalled();
 
-    fireEvent.click(screen.getByText(/Reset/i));
+    // Reset works without onClose
+    fireEvent.click(screen.getByLabelText(/Reset filters/i));
   });
 
   it("handles undefined activeMakes", () => {
@@ -328,7 +358,7 @@ describe("FilterSidebar", () => {
     const select = screen.getByLabelText(/Manufacturer/i);
     fireEvent.change(select, { target: { value: "John Deere" } });
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
+    // Auto-apply: filters update immediately when changed
     const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
     expect(calledWith.get("make")).toBe("John Deere");
   });
@@ -338,10 +368,429 @@ describe("FilterSidebar", () => {
     const select = screen.getByLabelText(/Auction Status/i);
     fireEvent.change(select, { target: { value: "closed" } });
 
-    fireEvent.click(screen.getByText(/Apply Filters/i));
+    // Auto-apply: filters update immediately when changed
     const calledWith = mockSetSearchParams.mock.calls[0][0] as URLSearchParams;
     expect(calledWith.get("status")).toBe("closed");
   });
-  // requires more complex interaction if they are not mocked.
-  // We can at least try to trigger the onValueChange if we can find the right way.
+
+  describe("authenticated session", () => {
+    beforeEach(() => {
+      (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+      (useQuery as Mock)
+        .mockReturnValueOnce(["John Deere", "Case IH"])
+        .mockReturnValueOnce(null);
+    });
+
+    it("shows Save Defaults and Clear Defaults buttons when authenticated", () => {
+      renderSidebar();
+      expect(screen.getByText("Save Defaults")).toBeInTheDocument();
+      expect(screen.getByText("Clear Defaults")).toBeInTheDocument();
+    });
+
+    it("calls updateMyPreferences when Save Defaults is clicked", () => {
+      const mockMutate = vi.fn();
+      (useMutation as Mock).mockReturnValue(mockMutate);
+
+      mockSearchParams.set("make", "John Deere");
+      (useQuery as Mock).mockReset();
+      (useQuery as Mock)
+        .mockReturnValueOnce(["John Deere", "Case IH"])
+        .mockReturnValueOnce(null);
+
+      renderSidebar();
+      fireEvent.click(screen.getByText("Save Defaults"));
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultMake: "John Deere" })
+      );
+    });
+
+    it("calls updateMyPreferences with undefined fields when Clear Defaults is clicked", () => {
+      const mockMutate = vi.fn();
+      (useMutation as Mock).mockReturnValue(mockMutate);
+
+      renderSidebar();
+      fireEvent.click(screen.getByText("Clear Defaults"));
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultMake: undefined })
+      );
+    });
+  });
+
+  it("applies saved preferences to filters when no URL params present", async () => {
+    const savedPrefs = {
+      defaultMake: "Case IH",
+      defaultMinYear: 2020,
+      defaultStatusFilter: "closed",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"]) // activeMakes
+      .mockReturnValueOnce(savedPrefs); // getMyPreferences
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    // After prefs load, the make select should reflect Case IH
+    const makeSelect = screen.getByLabelText(/Manufacturer/i);
+    expect(makeSelect).toHaveTextContent("Case IH");
+  });
+
+  it("URL params take priority over saved preferences", async () => {
+    mockSearchParams.set("make", "John Deere");
+
+    const savedPrefs = {
+      defaultMake: "Case IH",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    const makeSelect = screen.getByLabelText(/Manufacturer/i);
+    expect(makeSelect).toHaveTextContent("John Deere");
+  });
+
+  it("applies saved defaultStatusFilter when no URL params", async () => {
+    const savedPrefs = {
+      defaultStatusFilter: "closed",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Auction Status/i)).toHaveTextContent(
+      "Closed Auctions"
+    );
+  });
+
+  it("applies saved defaultMinYear and defaultMaxYear when no URL params", async () => {
+    const savedPrefs = {
+      defaultMinYear: 2018,
+      defaultMaxYear: 2023,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Minimum year/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Maximum year/i)).toBeInTheDocument();
+  });
+
+  it("applies saved defaultMinPrice and defaultMaxPrice when no URL params", async () => {
+    const savedPrefs = {
+      defaultMinPrice: 50000,
+      defaultMaxPrice: 500000,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Minimum price/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Maximum price/i)).toBeInTheDocument();
+  });
+
+  it("applies saved defaultMaxHours when no URL params", async () => {
+    const savedPrefs = {
+      defaultMaxHours: 3500,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Max Operating Hours/i)).toBeInTheDocument();
+  });
+
+  it("URL params take priority over preferences in all filter fields", async () => {
+    mockSearchParams.set("status", "closed");
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2020");
+    mockSearchParams.set("maxYear", "2023");
+    mockSearchParams.set("minPrice", "100000");
+    mockSearchParams.set("maxPrice", "500000");
+    mockSearchParams.set("maxHours", "1000");
+
+    const prefs = {
+      defaultStatusFilter: "all",
+      defaultMake: "Case IH",
+      defaultMinYear: 2015,
+      defaultMaxYear: 2025,
+      defaultMinPrice: 50000,
+      defaultMaxPrice: 1000000,
+      defaultMaxHours: 5000,
+    };
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"]) // first render activeMakes
+      .mockReturnValueOnce(prefs) // first render preferences
+      .mockReturnValue(["John Deere", "Case IH"]); // keep options available on re-renders
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    // URL params should win over prefs — verify via DOM state
+    // status: URL "closed" wins over prefs "all"
+    expect(screen.getByLabelText(/Auction Status/i)).toHaveTextContent(
+      "Closed Auctions"
+    );
+    // make: URL "John Deere" wins over prefs "Case IH" — option must be present for value to show
+    expect(screen.getByLabelText(/Manufacturer/i)).toHaveValue("John Deere");
+  });
+
+  it("calls updateMyPreferences with undefined when saveDefaults with empty fields", () => {
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultStatusFilter: "active",
+        defaultMake: undefined,
+        defaultMinYear: undefined,
+        defaultMaxYear: undefined,
+        defaultMinPrice: undefined,
+        defaultMaxPrice: undefined,
+        defaultMaxHours: undefined,
+      })
+    );
+  });
+
+  it("calls clearDefaults with all fields undefined", () => {
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+    fireEvent.click(screen.getByText("Clear Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      defaultStatusFilter: undefined,
+      defaultMake: undefined,
+      defaultMinYear: undefined,
+      defaultMaxYear: undefined,
+      defaultMinPrice: undefined,
+      defaultMaxPrice: undefined,
+      defaultMaxHours: undefined,
+    });
+  });
+
+  it("handles null values in preferences defaults", async () => {
+    const savedPrefs = {
+      defaultMake: null as unknown as string,
+      defaultMinYear: null,
+      defaultMaxYear: null,
+      defaultMinPrice: null,
+      defaultMaxPrice: null,
+      defaultMaxHours: null,
+      defaultStatusFilter: null as unknown as string,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Auction Status/i)).toBeInTheDocument();
+  });
+
+  it("handles partial preferences with some fields set", async () => {
+    const savedPrefs = {
+      defaultMake: "Case IH",
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    mockSearchParams = new URLSearchParams();
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Manufacturer/i)).toBeInTheDocument();
+  });
+
+  it("shows Save Defaults button with current filters as defaults", async () => {
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2020");
+
+    const savedPrefs = {
+      defaultMake: undefined,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs);
+
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultMake: "John Deere",
+        defaultMinYear: 2020,
+      })
+    );
+  });
+
+  it("does not apply preferences when preferences is undefined", async () => {
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(undefined); // No preferences
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    expect(screen.getByLabelText(/Auction Status/i)).toBeInTheDocument();
+  });
+
+  it("keeps URL params over preferences for all fields when both are present", async () => {
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2022");
+    mockSearchParams.set("maxYear", "2024");
+    mockSearchParams.set("minPrice", "100000");
+    mockSearchParams.set("maxPrice", "2000000");
+    mockSearchParams.set("maxHours", "5000");
+
+    const savedPrefs = {
+      defaultMake: "Case IH",
+      defaultMinYear: 2020,
+      defaultMaxYear: 2023,
+      defaultMinPrice: 50000,
+      defaultMaxPrice: 500000,
+      defaultMaxHours: 3500,
+    };
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(savedPrefs)
+      .mockReturnValueOnce(undefined);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    const makeSelect = screen.getByLabelText(/Manufacturer/i);
+    expect(makeSelect).toHaveTextContent("John Deere");
+  });
+
+  it("saveDefaults passes undefined for all empty filter fields", () => {
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultStatusFilter: "active",
+        defaultMake: undefined,
+        defaultMinYear: undefined,
+        defaultMaxYear: undefined,
+        defaultMinPrice: undefined,
+        defaultMaxPrice: undefined,
+        defaultMaxHours: undefined,
+      })
+    );
+  });
+
+  it("resetFilters calls onClose when provided", () => {
+    const onClose = vi.fn();
+    mockSearchParams.set("make", "John Deere");
+    renderSidebar(onClose);
+
+    fireEvent.click(screen.getByLabelText(/Reset filters/i));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("saveDefaults passes parsed values for non-empty filter fields", async () => {
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+
+    mockSearchParams.set("status", "closed");
+    mockSearchParams.set("make", "John Deere");
+    mockSearchParams.set("minYear", "2020");
+    mockSearchParams.set("maxYear", "2024");
+    mockSearchParams.set("minPrice", "100000");
+    mockSearchParams.set("maxPrice", "2000000");
+    mockSearchParams.set("maxHours", "5000");
+
+    (useQuery as Mock).mockReset();
+    (useQuery as Mock)
+      .mockReturnValueOnce(["John Deere", "Case IH"])
+      .mockReturnValueOnce(null);
+
+    renderSidebar();
+
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText("Save Defaults"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultStatusFilter: "closed",
+        defaultMake: "John Deere",
+        defaultMinYear: 2020,
+        defaultMaxYear: 2024,
+        defaultMinPrice: 100000,
+        defaultMaxPrice: 2000000,
+        defaultMaxHours: 5000,
+      })
+    );
+  });
 });

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -87,7 +87,9 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   // to avoid adding searchParams to its dependency array (which would cause it
   // to fire on external navigations and overwrite the URL with stale filters).
   const searchParamsRef = useRef(searchParams);
-  searchParamsRef.current = searchParams;
+  useEffect(() => {
+    searchParamsRef.current = searchParams;
+  }, [searchParams]);
 
   // Stable string representation used as a dep for the preferences effect.
   const searchParamsString = searchParams.toString();
@@ -134,6 +136,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
       isLocalUpdateRef.current = false;
       return;
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLocalFilters({
       status: searchParams.get("status") ?? "active",
       make: searchParams.get("make") ?? "",
@@ -146,40 +149,35 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   }, [searchParams]);
 
   // Apply saved preferences once when they arrive (only if not yet applied).
-  // searchParamsString in deps ensures a fresh searchParams closure is used
-  // when the effect fires after preferences load.
+  // Uses searchParamsRef to avoid stale closures; searchParamsString ensures
+  // the effect re-fires when the URL changes after preferences load.
   useLayoutEffect(() => {
     if (preferences && !prefsAppliedRef.current) {
       prefsAppliedRef.current = true;
+      const params = searchParamsRef.current;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLocalFilters({
         status:
-          searchParams.get("status") ??
-          preferences.defaultStatusFilter ??
-          "active",
-        make: searchParams.get("make") ?? preferences.defaultMake ?? "",
+          params.get("status") ?? preferences.defaultStatusFilter ?? "active",
+        make: params.get("make") ?? preferences.defaultMake ?? "",
         minYear:
-          searchParams.get("minYear") ??
-          preferences.defaultMinYear?.toString() ??
-          "",
+          params.get("minYear") ?? preferences.defaultMinYear?.toString() ?? "",
         maxYear:
-          searchParams.get("maxYear") ??
-          preferences.defaultMaxYear?.toString() ??
-          "",
+          params.get("maxYear") ?? preferences.defaultMaxYear?.toString() ?? "",
         minPrice:
-          searchParams.get("minPrice") ??
+          params.get("minPrice") ??
           preferences.defaultMinPrice?.toString() ??
           "",
         maxPrice:
-          searchParams.get("maxPrice") ??
+          params.get("maxPrice") ??
           preferences.defaultMaxPrice?.toString() ??
           "",
         maxHours:
-          searchParams.get("maxHours") ??
+          params.get("maxHours") ??
           preferences.defaultMaxHours?.toString() ??
           "",
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preferences, searchParamsString]);
 
   const updateParam = (key: keyof LocalFilters, value: string) => {
@@ -233,14 +231,6 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   const clearDefaults = async () => {
     if (!session) return;
     try {
-      prefsAppliedRef.current = true;
-      isLocalUpdateRef.current = true;
-      const defaultFilters = getDefaultFilters();
-      setLocalFilters(defaultFilters);
-      const newParams = new URLSearchParams();
-      const q = searchParams.get("q");
-      if (q) newParams.set("q", q);
-      setSearchParams(newParams);
       await updateMyPreferences({
         defaultStatusFilter: undefined,
         defaultMake: undefined,
@@ -250,6 +240,14 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         defaultMaxPrice: undefined,
         defaultMaxHours: undefined,
       });
+      prefsAppliedRef.current = true;
+      isLocalUpdateRef.current = true;
+      const defaultFilters = getDefaultFilters();
+      setLocalFilters(defaultFilters);
+      const newParams = new URLSearchParams();
+      const q = searchParams.get("q");
+      if (q) newParams.set("q", q);
+      setSearchParams(newParams);
       toast.success("Default filters cleared");
     } catch {
       toast.error("Failed to clear default filters");

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -55,6 +55,47 @@ const getDefaultFilters = (): LocalFilters => ({
 });
 
 /**
+ * Validates and normalizes filter values from URL parameters.
+ * Enforces the same rules as Home.tsx:
+ * - Only accepts allowed status values (active, closed, all)
+ * - Parses numeric params with parseInt and treats non-finite/NaN as empty strings
+ * - Trims and validates strings like make
+ * - Falls back to empty/default values when a param is invalid
+ *
+ * @param params - The URLSearchParams to parse
+ * @returns A normalized LocalFilters object
+ */
+const parseUrlFilters = (params: URLSearchParams): LocalFilters => {
+  // Validate status - only allow known values
+  const rawStatus = params.get("status");
+  const status =
+    rawStatus === "active" || rawStatus === "closed" || rawStatus === "all"
+      ? rawStatus
+      : "active";
+
+  // Validate and trim make
+  const make = (params.get("make") ?? "").trim();
+
+  // Parse numeric fields - only accept finite integers
+  const parseFiniteInt = (key: string): string => {
+    const val = params.get(key);
+    if (val === null) return "";
+    const parsed = parseInt(val, 10);
+    return Number.isFinite(parsed) ? parsed.toString() : "";
+  };
+
+  return {
+    status,
+    make,
+    minYear: parseFiniteInt("minYear"),
+    maxYear: parseFiniteInt("maxYear"),
+    minPrice: parseFiniteInt("minPrice"),
+    maxPrice: parseFiniteInt("maxPrice"),
+    maxHours: parseFiniteInt("maxHours"),
+  };
+};
+
+/**
  * Sidebar component for filtering auctions.
  *
  * @param props - Component props.
@@ -82,6 +123,8 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   // Tracks whether the next searchParams change was triggered locally (filter
   // change or reset) so the external-navigation sync effect can skip it.
   const isLocalUpdateRef = useRef<boolean>(true);
+  // Track the current user ID to detect user switches
+  const lastUserIdRef = useRef<string | undefined>(session?.user?.id);
 
   // Always-current reference to searchParams used inside the local→URL effect
   // to avoid adding searchParams to its dependency array (which would cause it
@@ -95,15 +138,8 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   const searchParamsString = searchParams.toString();
 
   // Initialize localFilters from search params only (preferences handled in effect)
-  const getInitialFilters = (): LocalFilters => ({
-    status: searchParams.get("status") ?? "active",
-    make: searchParams.get("make") ?? "",
-    minYear: searchParams.get("minYear") ?? "",
-    maxYear: searchParams.get("maxYear") ?? "",
-    minPrice: searchParams.get("minPrice") ?? "",
-    maxPrice: searchParams.get("maxPrice") ?? "",
-    maxHours: searchParams.get("maxHours") ?? "",
-  });
+  // Use the normalizer to ensure valid initial state
+  const getInitialFilters = (): LocalFilters => parseUrlFilters(searchParams);
 
   // Local state for debounced inputs
   const [localFilters, setLocalFilters] =
@@ -136,17 +172,21 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
       isLocalUpdateRef.current = false;
       return;
     }
+    // Use the normalizer to ensure valid state from URL
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLocalFilters({
-      status: searchParams.get("status") ?? "active",
-      make: searchParams.get("make") ?? "",
-      minYear: searchParams.get("minYear") ?? "",
-      maxYear: searchParams.get("maxYear") ?? "",
-      minPrice: searchParams.get("minPrice") ?? "",
-      maxPrice: searchParams.get("maxPrice") ?? "",
-      maxHours: searchParams.get("maxHours") ?? "",
-    });
+    setLocalFilters(parseUrlFilters(searchParams));
   }, [searchParams]);
+
+  // Reset preferences state when user changes
+  useEffect(() => {
+    const currentUserId = session?.user?.id;
+    if (currentUserId !== lastUserIdRef.current) {
+      lastUserIdRef.current = currentUserId;
+      // Reset the applied flag so preferences are re-applied for the new user
+      prefsAppliedRef.current = false;
+      isLocalUpdateRef.current = false;
+    }
+  }, [session?.user?.id]);
 
   // Apply saved preferences once when they arrive (only if not yet applied).
   // Uses searchParamsRef to avoid stale closures; searchParamsString ensures
@@ -155,27 +195,33 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
     if (preferences && !prefsAppliedRef.current) {
       prefsAppliedRef.current = true;
       const params = searchParamsRef.current;
+
+      // Parse and normalize URL filters first
+      const urlFilters = parseUrlFilters(params);
+
+      // Apply preferences as defaults only when URL params are not present
+      // Validate preference values using the same rules
+      const validateStatus = (val: string | undefined): string => {
+        return val === "active" || val === "closed" || val === "all"
+          ? val
+          : "active";
+      };
+
+      const validateNumber = (val: number | undefined): string => {
+        return val !== undefined && Number.isFinite(val) ? val.toString() : "";
+      };
+
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setLocalFilters({
-        status:
-          params.get("status") ?? preferences.defaultStatusFilter ?? "active",
-        make: params.get("make") ?? preferences.defaultMake ?? "",
-        minYear:
-          params.get("minYear") ?? preferences.defaultMinYear?.toString() ?? "",
-        maxYear:
-          params.get("maxYear") ?? preferences.defaultMaxYear?.toString() ?? "",
-        minPrice:
-          params.get("minPrice") ??
-          preferences.defaultMinPrice?.toString() ??
-          "",
-        maxPrice:
-          params.get("maxPrice") ??
-          preferences.defaultMaxPrice?.toString() ??
-          "",
-        maxHours:
-          params.get("maxHours") ??
-          preferences.defaultMaxHours?.toString() ??
-          "",
+        status: urlFilters.status !== "active"
+          ? urlFilters.status
+          : validateStatus(preferences.defaultStatusFilter),
+        make: urlFilters.make || (preferences.defaultMake ?? "").trim(),
+        minYear: urlFilters.minYear || validateNumber(preferences.defaultMinYear),
+        maxYear: urlFilters.maxYear || validateNumber(preferences.defaultMaxYear),
+        minPrice: urlFilters.minPrice || validateNumber(preferences.defaultMinPrice),
+        maxPrice: urlFilters.maxPrice || validateNumber(preferences.defaultMaxPrice),
+        maxHours: urlFilters.maxHours || validateNumber(preferences.defaultMaxHours),
       });
     }
   }, [preferences, searchParamsString]);
@@ -198,6 +244,13 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   const saveDefaults = async () => {
     if (!session) return;
     try {
+      // Use the same validation logic when saving
+      const validateAndParseInt = (val: string): number | undefined => {
+        if (!val) return undefined;
+        const parsed = parseInt(val, 10);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      };
+
       await updateMyPreferences({
         defaultStatusFilter:
           localFilters.status === "active" ||
@@ -205,22 +258,12 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
           localFilters.status === "all"
             ? (localFilters.status as "active" | "closed" | "all")
             : undefined,
-        defaultMake: localFilters.make || undefined,
-        defaultMinYear: localFilters.minYear
-          ? parseInt(localFilters.minYear, 10)
-          : undefined,
-        defaultMaxYear: localFilters.maxYear
-          ? parseInt(localFilters.maxYear, 10)
-          : undefined,
-        defaultMinPrice: localFilters.minPrice
-          ? parseInt(localFilters.minPrice, 10)
-          : undefined,
-        defaultMaxPrice: localFilters.maxPrice
-          ? parseInt(localFilters.maxPrice, 10)
-          : undefined,
-        defaultMaxHours: localFilters.maxHours
-          ? parseInt(localFilters.maxHours, 10)
-          : undefined,
+        defaultMake: localFilters.make.trim() || undefined,
+        defaultMinYear: validateAndParseInt(localFilters.minYear),
+        defaultMaxYear: validateAndParseInt(localFilters.maxYear),
+        defaultMinPrice: validateAndParseInt(localFilters.minPrice),
+        defaultMaxPrice: validateAndParseInt(localFilters.maxPrice),
+        defaultMaxHours: validateAndParseInt(localFilters.maxHours),
       });
       toast.success("Default filters saved");
     } catch {

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -1,8 +1,11 @@
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "convex/_generated/api";
 import { X, Filter, RotateCcw } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
-import { useState } from "react";
+import { useState, useRef, useLayoutEffect, useEffect } from "react";
+import { toast } from "sonner";
+
+import { useSession } from "@/lib/auth-client";
 
 import { Button } from "./ui/button";
 import {
@@ -37,6 +40,21 @@ interface LocalFilters {
 }
 
 /**
+ * Get default filter values.
+ *
+ * @returns A LocalFilters object with all fields set to their default empty/active state.
+ */
+const getDefaultFilters = (): LocalFilters => ({
+  status: "active",
+  make: "",
+  minYear: "",
+  maxYear: "",
+  minPrice: "",
+  maxPrice: "",
+  maxHours: "",
+});
+
+/**
  * Sidebar component for filtering auctions.
  *
  * @param props - Component props.
@@ -46,14 +64,36 @@ interface LocalFilters {
 export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeMakes = useQuery(api.auctions.getActiveMakes) ?? [];
+  const { data: session } = useSession();
+  const preferences = useQuery(
+    api.userPreferences.getMyPreferences,
+    session ? {} : "skip"
+  );
+  const updateMyPreferences = useMutation(
+    api.userPreferences.updateMyPreferences
+  );
 
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: 30 }, (_, i) =>
     (currentYear - i).toString()
   );
 
-  // Local state for debounced inputs
-  const [localFilters, setLocalFilters] = useState<LocalFilters>(() => ({
+  const prefsAppliedRef = useRef<boolean>(false);
+  // Tracks whether the next searchParams change was triggered locally (filter
+  // change or reset) so the external-navigation sync effect can skip it.
+  const isLocalUpdateRef = useRef<boolean>(true);
+
+  // Always-current reference to searchParams used inside the local→URL effect
+  // to avoid adding searchParams to its dependency array (which would cause it
+  // to fire on external navigations and overwrite the URL with stale filters).
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
+
+  // Stable string representation used as a dep for the preferences effect.
+  const searchParamsString = searchParams.toString();
+
+  // Initialize localFilters from search params only (preferences handled in effect)
+  const getInitialFilters = (): LocalFilters => ({
     status: searchParams.get("status") ?? "active",
     make: searchParams.get("make") ?? "",
     minYear: searchParams.get("minYear") ?? "",
@@ -61,31 +101,159 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
     minPrice: searchParams.get("minPrice") ?? "",
     maxPrice: searchParams.get("maxPrice") ?? "",
     maxHours: searchParams.get("maxHours") ?? "",
-  }));
+  });
+
+  // Local state for debounced inputs
+  const [localFilters, setLocalFilters] =
+    useState<LocalFilters>(getInitialFilters);
+
+  // Sync localFilters → URL whenever filters change locally.
+  // Uses searchParamsRef so it does not run on external URL changes.
+  useEffect(() => {
+    const currentParams = searchParamsRef.current;
+    const newParams = new URLSearchParams(currentParams.toString());
+    (Object.entries(localFilters) as [string, string][]).forEach(
+      ([key, value]) => {
+        if (value && !(key === "status" && value === "active")) {
+          newParams.set(key, value);
+        } else {
+          newParams.delete(key);
+        }
+      }
+    );
+    if (newParams.toString() !== currentParams.toString()) {
+      isLocalUpdateRef.current = true;
+      setSearchParams(newParams);
+    }
+  }, [localFilters, setSearchParams]);
+
+  // Sync URL → localFilters when the URL changes due to external navigation
+  // (e.g. browser back/forward). Skips updates caused by local filter changes.
+  useEffect(() => {
+    if (isLocalUpdateRef.current) {
+      isLocalUpdateRef.current = false;
+      return;
+    }
+    setLocalFilters({
+      status: searchParams.get("status") ?? "active",
+      make: searchParams.get("make") ?? "",
+      minYear: searchParams.get("minYear") ?? "",
+      maxYear: searchParams.get("maxYear") ?? "",
+      minPrice: searchParams.get("minPrice") ?? "",
+      maxPrice: searchParams.get("maxPrice") ?? "",
+      maxHours: searchParams.get("maxHours") ?? "",
+    });
+  }, [searchParams]);
+
+  // Apply saved preferences once when they arrive (only if not yet applied).
+  // searchParamsString in deps ensures a fresh searchParams closure is used
+  // when the effect fires after preferences load.
+  useLayoutEffect(() => {
+    if (preferences && !prefsAppliedRef.current) {
+      prefsAppliedRef.current = true;
+      setLocalFilters({
+        status:
+          searchParams.get("status") ??
+          preferences.defaultStatusFilter ??
+          "active",
+        make: searchParams.get("make") ?? preferences.defaultMake ?? "",
+        minYear:
+          searchParams.get("minYear") ??
+          preferences.defaultMinYear?.toString() ??
+          "",
+        maxYear:
+          searchParams.get("maxYear") ??
+          preferences.defaultMaxYear?.toString() ??
+          "",
+        minPrice:
+          searchParams.get("minPrice") ??
+          preferences.defaultMinPrice?.toString() ??
+          "",
+        maxPrice:
+          searchParams.get("maxPrice") ??
+          preferences.defaultMaxPrice?.toString() ??
+          "",
+        maxHours:
+          searchParams.get("maxHours") ??
+          preferences.defaultMaxHours?.toString() ??
+          "",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preferences, searchParamsString]);
 
   const updateParam = (key: keyof LocalFilters, value: string) => {
     setLocalFilters((prev) => ({ ...prev, [key]: value }));
   };
 
-  const applyFilters = () => {
-    const newParams = new URLSearchParams(searchParams);
-    Object.entries(localFilters).forEach(([key, value]) => {
-      if (value && !(key === "status" && value === "active")) {
-        newParams.set(key, value as string);
-      } else {
-        newParams.delete(key);
-      }
-    });
-    setSearchParams(newParams);
-    if (onClose) onClose();
-  };
-
-  const clearFilters = () => {
+  const resetFilters = () => {
+    prefsAppliedRef.current = true;
+    isLocalUpdateRef.current = true;
     const q = searchParams.get("q");
     const newParams = new URLSearchParams();
     if (q) newParams.set("q", q);
     setSearchParams(newParams);
+    setLocalFilters(getDefaultFilters());
     if (onClose) onClose();
+  };
+
+  const saveDefaults = async () => {
+    if (!session) return;
+    try {
+      await updateMyPreferences({
+        defaultStatusFilter:
+          localFilters.status === "active" ||
+          localFilters.status === "closed" ||
+          localFilters.status === "all"
+            ? (localFilters.status as "active" | "closed" | "all")
+            : undefined,
+        defaultMake: localFilters.make || undefined,
+        defaultMinYear: localFilters.minYear
+          ? parseInt(localFilters.minYear, 10)
+          : undefined,
+        defaultMaxYear: localFilters.maxYear
+          ? parseInt(localFilters.maxYear, 10)
+          : undefined,
+        defaultMinPrice: localFilters.minPrice
+          ? parseInt(localFilters.minPrice, 10)
+          : undefined,
+        defaultMaxPrice: localFilters.maxPrice
+          ? parseInt(localFilters.maxPrice, 10)
+          : undefined,
+        defaultMaxHours: localFilters.maxHours
+          ? parseInt(localFilters.maxHours, 10)
+          : undefined,
+      });
+      toast.success("Default filters saved");
+    } catch {
+      toast.error("Failed to save default filters");
+    }
+  };
+
+  const clearDefaults = async () => {
+    if (!session) return;
+    try {
+      prefsAppliedRef.current = true;
+      isLocalUpdateRef.current = true;
+      const defaultFilters = getDefaultFilters();
+      setLocalFilters(defaultFilters);
+      const newParams = new URLSearchParams();
+      const q = searchParams.get("q");
+      if (q) newParams.set("q", q);
+      setSearchParams(newParams);
+      await updateMyPreferences({
+        defaultStatusFilter: undefined,
+        defaultMake: undefined,
+        defaultMinYear: undefined,
+        defaultMaxYear: undefined,
+        defaultMinPrice: undefined,
+        defaultMaxPrice: undefined,
+        defaultMaxHours: undefined,
+      });
+      toast.success("Default filters cleared");
+    } catch {
+      toast.error("Failed to clear default filters");
+    }
   };
 
   const { status, ...otherFilters } = localFilters;
@@ -93,30 +261,42 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
     status !== "active" || Object.values(otherFilters).some((v) => v !== "");
 
   return (
-    <div className="flex flex-col h-full bg-card border-2 rounded-3xl overflow-hidden shadow-xl shadow-primary/5 animate-in slide-in-from-left-4 duration-300">
-      <div className="p-6 border-b flex justify-between items-center bg-muted/30">
+    <div className="flex flex-col h-full bg-card border-2 rounded-lg overflow-hidden shadow-xl shadow-primary/5 animate-in slide-in-from-left-4 duration-300">
+      <div className="p-4 border-b flex justify-between items-center bg-muted/30">
         <div className="flex items-center gap-2">
           <Filter className="h-4 w-4 text-primary" />
           <h2 className="font-black uppercase tracking-tight text-sm">
             Filter Equipment
           </h2>
         </div>
-        {onClose && (
+        <div className="flex items-center gap-1">
           <Button
             variant="ghost"
             size="icon"
-            onClick={onClose}
+            onClick={resetFilters}
             className="h-8 w-8 rounded-full"
-            aria-label="Close filters"
+            aria-label="Reset filters"
+            disabled={!hasFilters}
           >
-            <X className="h-4 w-4" />
+            <RotateCcw className="h-4 w-4" />
           </Button>
-        )}
+          {onClose && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="h-8 w-8 rounded-full"
+              aria-label="Close filters"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6 space-y-8">
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {/* Manufacturer Filter */}
-        <div className="space-y-3">
+        <div className="space-y-2">
           <label
             htmlFor="filter-make"
             className="text-[10px] font-black uppercase text-muted-foreground tracking-widest ml-1"
@@ -127,7 +307,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
             id="filter-make"
             value={localFilters.make}
             onChange={(e) => updateParam("make", e.target.value)}
-            className="w-full h-12 rounded-xl border-2 bg-background px-3 font-bold text-sm focus:ring-2 focus:ring-primary outline-none transition-all"
+            className="w-full h-10 rounded-md border-2 bg-background px-3 font-bold text-sm focus:ring-2 focus:ring-primary outline-none transition-all"
           >
             <option value="">All Manufacturers</option>
             {activeMakes.map((make) => (
@@ -139,11 +319,11 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         </div>
 
         {/* Year Range */}
-        <div className="space-y-3">
+        <div className="space-y-2">
           <label className="text-[10px] font-black uppercase text-muted-foreground tracking-widest ml-1">
             Year Model
           </label>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-2">
             <Select
               value={localFilters.minYear || "any"}
               onValueChange={(value: string) => {
@@ -152,7 +332,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
             >
               <SelectTrigger
                 aria-label="Minimum year"
-                className="h-12 rounded-xl border-2 font-bold"
+                className="h-10 rounded-md border-2 font-bold"
               >
                 <SelectValue placeholder="From" />
               </SelectTrigger>
@@ -173,7 +353,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
             >
               <SelectTrigger
                 aria-label="Maximum year"
-                className="h-12 rounded-xl border-2 font-bold"
+                className="h-10 rounded-md border-2 font-bold"
               >
                 <SelectValue placeholder="To" />
               </SelectTrigger>
@@ -190,14 +370,14 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         </div>
 
         {/* Price Range */}
-        <div className="space-y-3">
+        <div className="space-y-2">
           <label
             id="price-range-label"
             className="text-[10px] font-black uppercase text-muted-foreground tracking-widest ml-1"
           >
             Price Range (ZAR)
           </label>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-2">
             <Select
               value={localFilters.minPrice || "any"}
               onValueChange={(value: string) => {
@@ -207,7 +387,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
               <SelectTrigger
                 aria-labelledby="price-range-label"
                 aria-label="Minimum price"
-                className="h-12 rounded-xl border-2 font-bold"
+                className="h-10 rounded-md border-2 font-bold"
               >
                 <SelectValue placeholder="Min" />
               </SelectTrigger>
@@ -229,7 +409,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
               <SelectTrigger
                 aria-labelledby="price-range-label"
                 aria-label="Maximum price"
-                className="h-12 rounded-xl border-2 font-bold"
+                className="h-10 rounded-md border-2 font-bold"
               >
                 <SelectValue placeholder="Max" />
               </SelectTrigger>
@@ -246,7 +426,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         </div>
 
         {/* Operating Hours */}
-        <div className="space-y-3">
+        <div className="space-y-2">
           <label
             id="hours-label"
             className="text-[10px] font-black uppercase text-muted-foreground tracking-widest ml-1"
@@ -261,7 +441,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
           >
             <SelectTrigger
               aria-labelledby="hours-label"
-              className="h-12 rounded-xl border-2 font-bold"
+              className="h-10 rounded-md border-2 font-bold"
             >
               <SelectValue placeholder="Any" />
             </SelectTrigger>
@@ -278,7 +458,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         </div>
 
         {/* Auction Status Filter */}
-        <div className="space-y-3">
+        <div className="space-y-2">
           <label
             htmlFor="filter-status"
             className="text-[10px] font-black uppercase text-muted-foreground tracking-widest ml-1"
@@ -289,7 +469,7 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
             id="filter-status"
             value={localFilters.status}
             onChange={(e) => updateParam("status", e.target.value)}
-            className="w-full h-12 rounded-xl border-2 bg-background px-3 font-bold text-sm focus:ring-2 focus:ring-primary outline-none transition-all"
+            className="w-full h-10 rounded-md border-2 bg-background px-3 font-bold text-sm focus:ring-2 focus:ring-primary outline-none transition-all"
           >
             <option value="active">Active Auctions</option>
             <option value="closed">Closed Auctions</option>
@@ -298,22 +478,25 @@ export const FilterSidebar = ({ onClose }: FilterSidebarProps) => {
         </div>
       </div>
 
-      <div className="p-6 border-t bg-muted/10 grid grid-cols-2 gap-3">
-        <Button
-          variant="outline"
-          onClick={clearFilters}
-          className="h-12 rounded-xl font-black uppercase tracking-tight border-2 gap-2"
-          disabled={!hasFilters}
-        >
-          <RotateCcw className="h-4 w-4" />
-          Reset
-        </Button>
-        <Button
-          onClick={applyFilters}
-          className="h-12 rounded-xl font-black uppercase tracking-tight shadow-lg shadow-primary/20"
-        >
-          Apply Filters
-        </Button>
+      <div className="p-4 border-t bg-muted/10">
+        {session && (
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              variant="outline"
+              onClick={saveDefaults}
+              className="h-9 rounded-md font-black uppercase tracking-tight border-2 text-xs"
+            >
+              Save Defaults
+            </Button>
+            <Button
+              variant="outline"
+              onClick={clearDefaults}
+              className="h-9 rounded-md font-black uppercase tracking-tight border-2 text-xs"
+            >
+              Clear Defaults
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { BrowserRouter } from "react-router-dom";
-import { useMutation } from "convex/react";
+import * as convexReact from "convex/react";
 
 import { useSession } from "@/lib/auth-client";
 
@@ -11,7 +11,6 @@ function typedMutationMock<T>(_val: unknown): T {
   return _val as T;
 }
 
-// Mock Header and Footer to isolate Layout testing
 vi.mock("./header/Header", () => ({
   Header: () => <header data-testid="mock-header">Header</header>,
 }));
@@ -20,9 +19,10 @@ vi.mock("./Footer", () => ({
   Footer: () => <footer data-testid="mock-footer">Footer</footer>,
 }));
 
-// Mock Convex hooks for NotificationListener inside Layout
 vi.mock("convex/react", () => ({
-  useQuery: vi.fn(() => []),
+  useQuery: vi.fn(() => {
+    return [];
+  }),
   useMutation: vi.fn(),
   Authenticated: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
@@ -32,26 +32,30 @@ vi.mock("convex/react", () => ({
   ),
 }));
 
-// Mock auth client for NotificationListener
 vi.mock("@/lib/auth-client", () => ({
   useSession: vi.fn(),
 }));
 
 describe("Layout", () => {
+  const mockUseQuery = convexReact.useQuery as ReturnType<typeof vi.fn>;
+  const mockUseMutation = convexReact.useMutation as ReturnType<typeof vi.fn>;
+  const mockUseSession = useSession as ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useSession).mockReturnValue({
+    mockUseSession.mockReturnValue({
       data: null,
       isPending: false,
     } as unknown as ReturnType<typeof useSession>);
-    vi.mocked(useMutation).mockReturnValue(
-      typedMutationMock<ReturnType<typeof useMutation>>(
+    mockUseMutation.mockReturnValue(
+      typedMutationMock<ReturnType<typeof convexReact.useMutation>>(
         vi.fn().mockResolvedValue({})
       )
     );
   });
 
   it("renders children and includes Header and Footer", () => {
+    mockUseQuery.mockReturnValue(undefined);
     render(
       <BrowserRouter>
         <Layout>
@@ -67,20 +71,21 @@ describe("Layout", () => {
 
   it("handles syncUser failure", async () => {
     const mockSyncUser = vi.fn().mockRejectedValue(new Error("Sync Fail"));
-    vi.mocked(useSession).mockReturnValue(
+    mockUseSession.mockReturnValue(
       typedMutationMock<ReturnType<typeof useSession>>({
         data: { user: { id: "user1" } },
         isPending: false,
       })
     );
-    vi.mocked(useMutation).mockReturnValue(
-      typedMutationMock<ReturnType<typeof useMutation>>(
+    mockUseMutation.mockReturnValue(
+      typedMutationMock<ReturnType<typeof convexReact.useMutation>>(
         mockSyncUser.mockRejectedValue(new Error("Sync Fail"))
       )
     );
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
+    mockUseQuery.mockReturnValue(undefined);
     render(
       <BrowserRouter>
         <Layout>

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -21,7 +21,8 @@ vi.mock("./Footer", () => ({
 
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(() => {
-    return [];
+    // Default return; individual tests override via mockUseQuery
+    return undefined;
   }),
   useMutation: vi.fn(),
   Authenticated: ({ children }: { children: React.ReactNode }) => (
@@ -79,7 +80,7 @@ describe("Layout", () => {
     );
     mockUseMutation.mockReturnValue(
       typedMutationMock<ReturnType<typeof convexReact.useMutation>>(
-        mockSyncUser.mockRejectedValue(new Error("Sync Fail"))
+        mockSyncUser
       )
     );
 

--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -12,6 +12,7 @@ import {
   MessageSquare,
   ShoppingBasket,
   Tag,
+  ClipboardList,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -220,8 +221,17 @@ export function UserDropdown({
             to="/dashboard/listings"
             className="flex items-center gap-2 w-full"
           >
-            <Settings className="h-4 w-4" />
+            <ClipboardList className="h-4 w-4" />
             My Listings
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          asChild
+          className="rounded-xl font-bold uppercase text-[10px] tracking-wide h-10"
+        >
+          <Link to="/settings" className="flex items-center gap-2 w-full">
+            <Settings className="h-4 w-4" />
+            Settings
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem

--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -227,7 +227,7 @@ export function UserDropdown({
         </DropdownMenuItem>
         <DropdownMenuItem
           asChild
-          className="rounded-xl font-bold uppercase text-[10px] tracking-wide h-10"
+          className="rounded-md font-bold uppercase text-[10px] tracking-wide h-10"
         >
           <Link to="/settings" className="flex items-center gap-2 w-full">
             <Settings className="h-4 w-4" />

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { BrowserRouter, useSearchParams } from "react-router-dom";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
 
 import { useSession } from "@/lib/auth-client";
 
@@ -10,6 +10,7 @@ import Home from "./Home";
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(),
   usePaginatedQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -410,6 +411,96 @@ describe("Home Page Full Coverage", () => {
     (useQuery as Mock).mockReturnValue(undefined);
     renderHome();
     expect(screen.getAllByTestId("auction-card")).toHaveLength(2);
+  });
+
+  it("applies saved viewMode preference on load", async () => {
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    // First useQuery call → preferences, second → watchedAuctionIds
+    (useQuery as Mock)
+      .mockReturnValueOnce({ viewMode: "compact", sidebarOpen: false })
+      .mockReturnValueOnce(["1"]);
+
+    renderHome();
+
+    await act(async () => {});
+
+    expect(screen.getByText(/Auction 1 \(compact\)/i)).toBeInTheDocument();
+  });
+
+  it("applies saved sidebarOpen preference on load", async () => {
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock)
+      .mockReturnValueOnce({ viewMode: "detailed", sidebarOpen: true })
+      .mockReturnValueOnce(["1"]);
+
+    renderHome();
+
+    await act(async () => {});
+
+    expect(screen.getByText(/Hide Filters/i)).toBeInTheDocument();
+  });
+
+  it("fires updateMyPreferences when authenticated user toggles view mode", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByText(/Compact/i));
+
+    expect(mockMutate).toHaveBeenCalledWith({ viewMode: "compact" });
+  });
+
+  it("fires updateMyPreferences when authenticated user toggles sidebar", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByText(/Show Filters/i));
+
+    expect(mockMutate).toHaveBeenCalledWith({ sidebarOpen: true });
+  });
+
+  it("does not fire updateMyPreferences when unauthenticated user toggles view mode", () => {
+    const mockMutate = vi.fn();
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: null, isPending: false });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByText(/Compact/i));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("fires updateMyPreferences when authenticated user clicks Detailed", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({
+      data: { user: { id: "u1" } },
+      isPending: false,
+    });
+    (useQuery as Mock).mockReturnValue(null);
+
+    renderHome();
+    fireEvent.click(screen.getByRole("button", { name: "Detailed" }));
+
+    expect(mockMutate).toHaveBeenCalledWith({ viewMode: "detailed" });
   });
 
   it("applies compact grid classes in loading state", () => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 // app/src/pages/Home.tsx
-import { useState } from "react";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useState, useRef, useLayoutEffect } from "react";
+import { useQuery, useMutation, usePaginatedQuery } from "convex/react";
 import { api } from "convex/_generated/api";
 import { Link, useSearchParams } from "react-router-dom";
 import { SlidersHorizontal, ChevronDown } from "lucide-react";
@@ -34,9 +34,18 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
  * @returns The JSX element for the Home page
  */
 export default function Home() {
-  const { isPending } = useSession();
+  const { data: session, isPending } = useSession();
   const [searchParams] = useSearchParams();
   const isMobile = useMediaQuery("(max-width: 768px)");
+
+  const preferences = useQuery(
+    api.userPreferences.getMyPreferences,
+    session ? {} : "skip"
+  );
+  const updateMyPreferences = useMutation(
+    api.userPreferences.updateMyPreferences
+  );
+
   const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
   const [isDesktopSidebarOpen, setIsDesktopSidebarOpen] = useState(false);
 
@@ -44,9 +53,30 @@ export default function Home() {
   const [manualViewMode, setManualViewMode] = useState<
     "compact" | "detailed" | null
   >(null);
+  const prefsAppliedRef = useRef<boolean | null>(null);
 
-  // Derive viewMode from isMobile, but respect manual override
-  const viewMode = manualViewMode ?? (isMobile ? "compact" : "detailed");
+  // Apply saved preferences once when they arrive
+  useLayoutEffect(() => {
+    if (preferences && prefsAppliedRef.current == null) {
+      prefsAppliedRef.current = true;
+      if (preferences.viewMode != null) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setManualViewMode(preferences.viewMode);
+      }
+      if (preferences.sidebarOpen != null) {
+        setIsDesktopSidebarOpen(preferences.sidebarOpen);
+      }
+    }
+  }, [preferences]);
+
+  // Derive viewMode from isMobile, but respect manual override and saved preferences
+  const viewMode =
+    manualViewMode ??
+    (session
+      ? (preferences?.viewMode ?? (isMobile ? "compact" : "detailed"))
+      : isMobile
+        ? "compact"
+        : "detailed");
 
   // Extract filter params
   let searchQuery = searchParams.get("q") ?? undefined;
@@ -63,7 +93,10 @@ export default function Home() {
   };
 
   const rawStatus = searchParams.get("status");
-  const statusFilter = isValidStatus(rawStatus) ? rawStatus : "active";
+  // Apply saved status from preferences as default when no status in URL
+  const statusFilter = isValidStatus(rawStatus)
+    ? rawStatus
+    : (preferences?.defaultStatusFilter ?? "active");
 
   const parseFiniteInt = (key: string) => {
     const val = searchParams.get(key);
@@ -159,7 +192,7 @@ export default function Home() {
           )}
         >
           <div className="h-full w-80">
-            <FilterSidebar key={searchParams.toString()} />
+            <FilterSidebar />
           </div>
         </aside>
 
@@ -180,7 +213,6 @@ export default function Home() {
             {/* Sidebar Container */}
             <div className="absolute inset-y-0 left-0 w-[280px] sm:w-80 z-20">
               <FilterSidebar
-                key={searchParams.toString()}
                 onClose={() => {
                   setIsMobileFilterOpen(false);
                 }}
@@ -223,7 +255,9 @@ export default function Home() {
               <Button
                 variant={isDesktopSidebarOpen ? "default" : "outline"}
                 onClick={() => {
-                  setIsDesktopSidebarOpen(!isDesktopSidebarOpen);
+                  const next = !isDesktopSidebarOpen;
+                  setIsDesktopSidebarOpen(next);
+                  if (session) void updateMyPreferences({ sidebarOpen: next });
                 }}
                 className="hidden lg:flex h-10 px-4 rounded-xl border-2 gap-2 font-bold uppercase text-xs"
               >
@@ -238,6 +272,8 @@ export default function Home() {
                   size="sm"
                   onClick={() => {
                     setManualViewMode("detailed");
+                    if (session)
+                      void updateMyPreferences({ viewMode: "detailed" });
                   }}
                   className="h-8 px-3 rounded-lg text-[10px] font-black uppercase"
                 >
@@ -248,6 +284,8 @@ export default function Home() {
                   size="sm"
                   onClick={() => {
                     setManualViewMode("compact");
+                    if (session)
+                      void updateMyPreferences({ viewMode: "compact" });
                   }}
                   className="h-8 px-3 rounded-lg text-[10px] font-black uppercase"
                 >

--- a/src/pages/Profile.test.tsx
+++ b/src/pages/Profile.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
 
 import Profile from "./Profile";
 
@@ -15,6 +15,7 @@ interface AuctionCardProps {
 vi.mock("convex/react", () => ({
   useQuery: vi.fn(),
   usePaginatedQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn()),
 }));
 
 const { mockApi } = vi.hoisted(() => ({
@@ -275,6 +276,342 @@ describe("Profile Page", () => {
     renderProfile();
     expect(
       screen.queryByText(/Lichtenburg, North West Province/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Edit button only for profile owner", () => {
+    renderProfile("user1");
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it("does not show Edit button for non-owner", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile)
+        return { userId: "other", _id: "other" };
+      if (apiPath === mockApi.auctions.getSellerInfo) return mockSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+    renderProfile("user1");
+    expect(
+      screen.queryByRole("button", { name: /edit/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens edit form when Edit button is clicked", () => {
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/location/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/company name/i)).toBeInTheDocument();
+  });
+
+  it("cancels editing and restores view mode", () => {
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByLabelText(/bio/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it("calls updateMyProfile and closes form on save", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    fireEvent.change(screen.getByLabelText(/bio/i), {
+      target: { value: "New bio text" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ bio: "New bio text" })
+    );
+    expect(screen.queryByLabelText(/bio/i)).not.toBeInTheDocument();
+  });
+
+  it("shows Saving... while mutation is in-flight", async () => {
+    let resolvePromise: () => void;
+    const pendingPromise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+    (useMutation as Mock).mockReturnValue(() => pendingPromise);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    // Click save — mutation is pending
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    expect(screen.getByText("Saving...")).toBeInTheDocument();
+
+    // Resolve the mutation
+    await act(async () => {
+      resolvePromise!();
+    });
+
+    expect(screen.queryByText("Saving...")).not.toBeInTheDocument();
+  });
+
+  it("submits undefined for empty trimmed fields", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    // Leave all fields empty
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      bio: undefined,
+      location: undefined,
+      companyName: undefined,
+    });
+  });
+
+  it("logs error and stays in edit mode when save fails", async () => {
+    const mockMutate = vi.fn().mockRejectedValue(new Error("Network error"));
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(spy).toHaveBeenCalled();
+    // Edit form should still be open after failure
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it("updates location and companyName fields in edit form", async () => {
+    const mockMutate = vi.fn().mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+
+    renderProfile("user1");
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    fireEvent.change(screen.getByLabelText(/location/i), {
+      target: { value: "Durban, KZN" },
+    });
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: "Sunrise Farms" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "Durban, KZN",
+        companyName: "Sunrise Farms",
+      })
+    );
+  });
+
+  it("shows admin activity item when user has admin role", () => {
+    const adminSellerInfo = {
+      ...mockSellerInfo,
+      name: "Admin User",
+      role: "admin",
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return adminSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds)
+        return ["auction1"];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Admin role assigned")).toBeInTheDocument();
+  });
+
+  it("handles single-word name for getInitials", () => {
+    const shortNameSellerInfo = {
+      ...mockSellerInfo,
+      name: "Bob",
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return shortNameSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds)
+        return ["auction1"];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("shows verification requested activity for non-admin user", () => {
+    renderProfile("user1");
+
+    expect(screen.getByText("Verification requested")).toBeInTheDocument();
+  });
+
+  it("shows Complete Verification button for unverified owner", () => {
+    const unverifiedSellerInfo = {
+      ...mockSellerInfo,
+      isVerified: false,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return unverifiedSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(
+      screen.getByRole("button", { name: /complete verification/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+  });
+
+  it("shows — for Avg Sale when avgSalePrice is undefined", () => {
+    const noAvgSellerInfo = {
+      ...mockSellerInfo,
+      avgSalePrice: undefined,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return noAvgSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Avg Sale")).toBeInTheDocument();
+  });
+
+  it("renders ?? initials when name is undefined", () => {
+    const noNameSellerInfo = {
+      ...mockSellerInfo,
+      name: undefined,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return noNameSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("??")).toBeInTheDocument();
+  });
+
+  it("shows Unknown date for activity when createdAt is undefined", () => {
+    const noDateSellerInfo = {
+      ...mockSellerInfo,
+      createdAt: undefined,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return noDateSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows unverified badge for unverified seller", () => {
+    const unverifiedSellerInfo = {
+      ...mockSellerInfo,
+      isVerified: false,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return unverifiedSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+  });
+
+  it("shows Admin badge for admin role", () => {
+    const adminSellerInfo = {
+      ...mockSellerInfo,
+      role: "admin",
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile) return mockMyProfile;
+      if (apiPath === mockApi.auctions.getSellerInfo) return adminSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+
+  it("does not show Complete Verification button for verified owner", () => {
+    renderProfile("user1");
+
+    expect(
+      screen.queryByRole("button", { name: /complete verification/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders loading indicator during LoadingMore pagination", () => {
+    (usePaginatedQuery as Mock).mockReturnValue({
+      results: mockListings,
+      status: "LoadingMore",
+      loadMore: vi.fn(),
+    });
+
+    renderProfile();
+
+    const loadingElements = screen.getAllByText("Loading...");
+    expect(loadingElements.length).toBeGreaterThan(0);
+  });
+
+  it("does not show Complete Verification button for non-owner", () => {
+    const unverifiedSellerInfo = {
+      ...mockSellerInfo,
+      isVerified: false,
+    };
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.users.getMyProfile)
+        return { ...mockMyProfile, userId: "other", _id: "other" };
+      if (apiPath === mockApi.auctions.getSellerInfo)
+        return unverifiedSellerInfo;
+      if (apiPath === mockApi.watchlist.getWatchedAuctionIds) return [];
+      return null;
+    });
+
+    renderProfile("user1");
+
+    expect(
+      screen.queryByRole("button", { name: /complete verification/i })
     ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from "react-router-dom";
-import { useQuery, usePaginatedQuery } from "convex/react";
+import { useQuery, usePaginatedQuery, useMutation } from "convex/react";
 import { api } from "convex/_generated/api";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -20,7 +20,12 @@ import {
   Mail,
   CreditCard,
   FileText,
+  Pencil,
+  X,
+  Check,
+  Building2,
 } from "lucide-react";
+import { useState } from "react";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -28,6 +33,8 @@ import { LoadingIndicator } from "@/components/LoadingIndicator";
 import { ProfileSkeleton } from "@/components/ProfileSkeleton";
 import { Button } from "@/components/ui/button";
 import { AuctionCard } from "@/components/auction/AuctionCard";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 
 interface ActivityItem {
   id: string;
@@ -166,6 +173,36 @@ export default function Profile() {
     !isProfileLoading &&
     (myProfile?.userId === userId || myProfile?._id === userId);
 
+  const updateMyProfile = useMutation(api.users.updateMyProfile);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState({
+    bio: myProfile?.profile?.bio ?? "",
+    location: myProfile?.profile?.location ?? "",
+    companyName: myProfile?.profile?.companyName ?? "",
+  });
+
+  const handleSaveProfile = async () => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await updateMyProfile({
+        bio: editForm.bio || undefined,
+        location: editForm.location || undefined,
+        companyName: editForm.companyName || undefined,
+      });
+      setIsEditing(false);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save profile";
+      setSaveError(message);
+      console.error("Failed to save profile:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const sellerInfo = useQuery(api.auctions.getSellerInfo, {
     sellerId: userId ?? "",
   });
@@ -229,9 +266,29 @@ export default function Profile() {
                 </div>
               </div>
 
-              <h1 className="text-2xl font-black text-primary uppercase leading-none mb-2">
-                {sellerInfo.name}
-              </h1>
+              <div className="flex items-start justify-between">
+                <h1 className="text-2xl font-black text-primary uppercase leading-none mb-2">
+                  {sellerInfo.name}
+                </h1>
+                {isOwner && !isEditing && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setEditForm({
+                        bio: myProfile?.profile?.bio ?? "",
+                        location: myProfile?.profile?.location ?? "",
+                        companyName: myProfile?.profile?.companyName ?? "",
+                      });
+                      setIsEditing(true);
+                    }}
+                    className="h-8 px-2 rounded-md font-bold uppercase text-xs"
+                  >
+                    <Pencil className="h-3 w-3 mr-1" />
+                    Edit
+                  </Button>
+                )}
+              </div>
 
               <div className="flex flex-wrap gap-2 mb-3">
                 {sellerInfo.role === "admin" && (
@@ -257,20 +314,125 @@ export default function Profile() {
                 Member since {formatMemberSince(sellerInfo.createdAt)}
               </p>
 
-              {sellerInfo.bio && (
+              {isEditing ? (
+                <div className="space-y-3">
+                  <div>
+                    <label
+                      htmlFor="profile-bio"
+                      className="text-[10px] font-black uppercase text-muted-foreground tracking-widest"
+                    >
+                      Bio
+                    </label>
+                    <Textarea
+                      id="profile-bio"
+                      value={editForm.bio}
+                      onChange={(e) =>
+                        setEditForm({ ...editForm, bio: e.target.value })
+                      }
+                      placeholder="Tell us about yourself..."
+                      className="mt-1 min-h-[80px] rounded-md border-2 font-bold text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="profile-location"
+                      className="text-[10px] font-black uppercase text-muted-foreground tracking-widest"
+                    >
+                      Location
+                    </label>
+                    <Input
+                      id="profile-location"
+                      value={editForm.location}
+                      onChange={(e) =>
+                        setEditForm({ ...editForm, location: e.target.value })
+                      }
+                      placeholder="City, Province"
+                      className="mt-1 rounded-md border-2 font-bold text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="profile-company-name"
+                      className="text-[10px] font-black uppercase text-muted-foreground tracking-widest"
+                    >
+                      Company Name
+                    </label>
+                    <Input
+                      id="profile-company-name"
+                      value={editForm.companyName}
+                      onChange={(e) =>
+                        setEditForm({
+                          ...editForm,
+                          companyName: e.target.value,
+                        })
+                      }
+                      placeholder="Your company name"
+                      className="mt-1 rounded-md border-2 font-bold text-sm"
+                    />
+                  </div>
+                  {saveError && (
+                    <p className="text-sm text-destructive mt-2">{saveError}</p>
+                  )}
+                  <div className="flex gap-2 pt-2">
+                    <Button
+                      onClick={handleSaveProfile}
+                      disabled={isSaving}
+                      className="flex-1 h-9 rounded-md font-black uppercase text-xs"
+                    >
+                      {isSaving ? (
+                        <>
+                          <span className="animate-pulse">Saving...</span>
+                        </>
+                      ) : (
+                        <>
+                          <Check className="h-3 w-3 mr-1" />
+                          Save
+                        </>
+                      )}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        setEditForm({
+                          bio: myProfile?.profile?.bio ?? "",
+                          location: myProfile?.profile?.location ?? "",
+                          companyName: myProfile?.profile?.companyName ?? "",
+                        });
+                        setIsEditing(false);
+                      }}
+                      disabled={isSaving}
+                      className="flex-1 h-9 rounded-md font-black uppercase text-xs border-2"
+                    >
+                      <X className="h-3 w-3 mr-1" />
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
                 <>
-                  <div className="h-px bg-border my-4" />
-                  <p className="text-sm text-muted-foreground leading-relaxed">
-                    {sellerInfo.bio}
-                  </p>
-                </>
-              )}
+                  {sellerInfo.bio && (
+                    <>
+                      <div className="h-px bg-border my-4" />
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {sellerInfo.bio}
+                      </p>
+                    </>
+                  )}
 
-              {sellerInfo.location && (
-                <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-3">
-                  <MapPin className="h-4 w-4" />
-                  {sellerInfo.location}
-                </p>
+                  {sellerInfo.location && (
+                    <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-3">
+                      <MapPin className="h-4 w-4" />
+                      {sellerInfo.location}
+                    </p>
+                  )}
+
+                  {sellerInfo.companyName && (
+                    <p className="text-sm text-muted-foreground flex items-center gap-1.5 mt-3">
+                      <Building2 className="h-4 w-4" />
+                      {sellerInfo.companyName}
+                    </p>
+                  )}
+                </>
               )}
             </CardContent>
 

--- a/src/pages/Settings.test.tsx
+++ b/src/pages/Settings.test.tsx
@@ -1,0 +1,325 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { useQuery, useMutation } from "convex/react";
+import React from "react";
+
+import { useSession } from "@/lib/auth-client";
+
+import Settings from "./Settings";
+
+vi.mock("convex/react", () => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(() => vi.fn().mockResolvedValue(undefined)),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: vi.fn(() => ({ data: { user: { id: "u1" } } })),
+}));
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    userPreferences: {
+      getMyPreferences: { name: "userPreferences:getMyPreferences" },
+      updateMyPreferences: { name: "userPreferences:updateMyPreferences" },
+    },
+    users: {
+      getMyProfile: { name: "users:getMyProfile" },
+    },
+  },
+}));
+
+vi.mock("convex/_generated/api", () => ({ api: mockApi }));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <label className={className}>{children}</label>,
+}));
+
+vi.mock("@/components/ui/select", () => {
+  interface MockProps {
+    children: React.ReactNode;
+    onValueChange?: (v: string) => void;
+    value?: string;
+  }
+  return {
+    Select: ({ children, onValueChange }: MockProps) => (
+      <div>
+        {Array.isArray(children)
+          ? children.map((child) =>
+              child?.props?.children
+                ? { ...child, props: { ...child.props, onValueChange } }
+                : child
+            )
+          : children}
+      </div>
+    ),
+    SelectTrigger: ({ children }: MockProps) => <div>{children}</div>,
+    SelectValue: () => <span />,
+    SelectContent: ({
+      children,
+      onValueChange,
+    }: MockProps & { onValueChange?: (v: string) => void }) => (
+      <div>
+        {Array.isArray(children)
+          ? children.map(
+              (
+                child: React.ReactElement<{
+                  value: string;
+                  onClick?: () => void;
+                }>
+              ) =>
+                React.isValidElement(child)
+                  ? React.cloneElement(child, {
+                      onClick: () => onValueChange?.(child.props.value),
+                    })
+                  : child
+            )
+          : children}
+      </div>
+    ),
+    SelectItem: ({
+      children,
+      value,
+      onClick,
+    }: {
+      children: React.ReactNode;
+      value: string;
+      onClick?: () => void;
+    }) => (
+      <button data-testid={`select-item-${value}`} onClick={onClick}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+vi.mock("@/components/LoadingIndicator", () => ({
+  LoadingPage: ({ message }: { message: string }) => <div>{message}</div>,
+}));
+
+describe("Settings Page", () => {
+  const mockMutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutate.mockResolvedValue(undefined);
+    (useMutation as Mock).mockReturnValue(mockMutate);
+    (useSession as Mock).mockReturnValue({ data: { user: { id: "u1" } } });
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences) return null;
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "buyer" } };
+      return null;
+    });
+  });
+
+  const renderSettings = () =>
+    render(
+      <BrowserRouter>
+        <Settings />
+      </BrowserRouter>
+    );
+
+  it("renders loading state when preferences are undefined", () => {
+    (useQuery as Mock).mockReturnValue(undefined);
+    renderSettings();
+    expect(screen.getByText("Loading settings...")).toBeInTheDocument();
+  });
+
+  it("renders all sections", () => {
+    renderSettings();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Display")).toBeInTheDocument();
+    expect(screen.getByText("Bidding")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+  });
+
+  it("does not render seller-only section for non-sellers", () => {
+    renderSettings();
+    expect(
+      screen.queryByText("Auction Approval Notifications")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders seller-only section for sellers", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences) return null;
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "seller" } };
+      return null;
+    });
+    renderSettings();
+    expect(
+      screen.getByText("Auction Approval Notifications")
+    ).toBeInTheDocument();
+  });
+
+  it("toggles sidebar switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show Filter Sidebar by Default" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({ sidebarOpen: true });
+  });
+
+  it("toggles bid confirmation switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Require Bid Confirmation" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      biddingRequireConfirmation: true,
+    });
+  });
+
+  it("toggles proxy bid switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Enable Proxy Bidding by Default" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({ biddingProxyBidDefault: true });
+  });
+
+  it("toggles outbid alert switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(screen.getByRole("switch", { name: "Outbid Alerts" }));
+    expect(mockMutate).toHaveBeenCalledWith({ notificationsBidOutbid: false });
+  });
+
+  it("toggles auction won switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Auction Won Notifications" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({ notificationsAuctionWon: false });
+  });
+
+  it("toggles email notifications switch and calls mutation", () => {
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Email Notifications" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      notificationsEmailEnabled: true,
+    });
+  });
+
+  it("does not call mutation when session is null", () => {
+    (useSession as Mock).mockReturnValue({ data: null });
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show Filter Sidebar by Default" })
+    );
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("reflects saved preferences in switch aria-checked", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences)
+        return { sidebarOpen: true, biddingRequireConfirmation: true };
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "buyer" } };
+      return null;
+    });
+    renderSettings();
+    expect(
+      screen.getByRole("switch", { name: "Show Filter Sidebar by Default" })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("switch", { name: "Require Bid Confirmation" })
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles seller auction approval switch for sellers", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences) return null;
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "seller" } };
+      return null;
+    });
+    renderSettings();
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Auction Approval Notifications" })
+    );
+    expect(mockMutate).toHaveBeenCalledWith({
+      notificationsSellerAuctionApproved: false,
+    });
+  });
+
+  it("handles view mode change through select", () => {
+    renderSettings();
+    const selectItems = screen.getAllByTestId("select-item-detailed");
+    fireEvent.click(selectItems[0]);
+    expect(mockMutate).toHaveBeenCalledWith({ viewMode: "detailed" });
+  });
+
+  it("handles default status filter change through select", () => {
+    renderSettings();
+    const selectItems = screen.getAllByTestId("select-item-all");
+    fireEvent.click(selectItems[0]);
+    expect(mockMutate).toHaveBeenCalledWith({ defaultStatusFilter: "all" });
+  });
+
+  it("handles watchlist ending alerts change through select", () => {
+    renderSettings();
+    const selectItems = screen.getAllByTestId("select-item-24h");
+    fireEvent.click(selectItems[0]);
+    expect(mockMutate).toHaveBeenCalledWith({
+      notificationsWatchlistEnding: "24h",
+    });
+  });
+
+  it("renders all toggles in their non-default CSS state", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences)
+        return {
+          biddingProxyBidDefault: true,
+          notificationsBidOutbid: false,
+          notificationsAuctionWon: false,
+          notificationsSellerAuctionApproved: false,
+          notificationsEmailEnabled: true,
+        };
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "seller" } };
+      return null;
+    });
+    renderSettings();
+    expect(
+      screen.getByRole("switch", { name: "Enable Proxy Bidding by Default" })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("switch", { name: "Outbid Alerts" })
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("switch", { name: "Auction Won Notifications" })
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("switch", { name: "Auction Approval Notifications" })
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("switch", { name: "Email Notifications" })
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders with preferences set to null values", () => {
+    (useQuery as Mock).mockImplementation((apiPath) => {
+      if (apiPath === mockApi.userPreferences.getMyPreferences)
+        return {
+          viewMode: null,
+          sidebarOpen: null,
+          notificationsWatchlistEnding: null,
+        };
+      if (apiPath === mockApi.users.getMyProfile)
+        return { profile: { role: "buyer" } };
+      return null;
+    });
+    renderSettings();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -90,14 +90,40 @@ export default function Settings() {
 
   const isSeller = myProfile?.profile?.role === "seller";
 
-  const update = (fields: Parameters<typeof updateMyPreferences>[0]) => {
-    if (!session) return;
+  let isSaving = false;
+
+  const update = (
+    fieldsOrUpdater:
+      | Parameters<typeof updateMyPreferences>[0]
+      | ((
+          current: NonNullable<typeof preferences>
+        ) => Parameters<typeof updateMyPreferences>[0])
+  ) => {
+    if (!session) {
+      toast.error("Not signed in");
+      return;
+    }
+
+    if (isSaving) {
+      return;
+    }
+
+    isSaving = true;
+
+    const fields =
+      typeof fieldsOrUpdater === "function"
+        ? fieldsOrUpdater(preferences!)
+        : fieldsOrUpdater;
+
     updateMyPreferences(fields)
       .then(() => {
         toast.success("Setting saved");
       })
       .catch(() => {
         toast.error("Failed to save setting");
+      })
+      .finally(() => {
+        isSaving = false;
       });
   };
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -48,6 +48,12 @@ function ToggleSwitch({
         aria-label={label}
         aria-checked={checked}
         onClick={onChange}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onChange();
+          }
+        }}
         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${
           checked ? "bg-primary" : "bg-input"
         }`}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,278 @@
+import { useQuery, useMutation } from "convex/react";
+import { api } from "convex/_generated/api";
+import { toast } from "sonner";
+
+import { useSession } from "@/lib/auth-client";
+import { LoadingPage } from "@/components/LoadingIndicator";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * Reusable toggle switch button.
+ *
+ * @param root0 - ToggleSwitch props.
+ * @param root0.label - Accessible label for the switch.
+ * @param root0.checked - Whether the switch is on.
+ * @param root0.onChange - Callback when the switch is toggled.
+ * @param root0.description - Optional description text below the label.
+ * @returns The toggle switch JSX element.
+ */
+function ToggleSwitch({
+  label,
+  checked,
+  onChange,
+  description,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+  description?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <Label className="text-sm font-bold">{label}</Label>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-label={label}
+        aria-checked={checked}
+        onClick={onChange}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${
+          checked ? "bg-primary" : "bg-input"
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-background transition-transform ${
+            checked ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * User settings page for managing persistent preferences.
+ *
+ * Allows authenticated users to configure display, bidding, and notification preferences.
+ * Changes are persisted automatically to Convex on each interaction.
+ *
+ * @returns The settings page JSX element.
+ */
+export default function Settings() {
+  const { data: session } = useSession();
+  const preferences = useQuery(api.userPreferences.getMyPreferences, {});
+  const myProfile = useQuery(api.users.getMyProfile, {});
+  const updateMyPreferences = useMutation(
+    api.userPreferences.updateMyPreferences
+  );
+
+  if (preferences === undefined || myProfile === undefined) {
+    return <LoadingPage message="Loading settings..." />;
+  }
+
+  const isSeller = myProfile?.profile?.role === "seller";
+
+  const update = (fields: Parameters<typeof updateMyPreferences>[0]) => {
+    if (!session) return;
+    updateMyPreferences(fields)
+      .then(() => {
+        toast.success("Setting saved");
+      })
+      .catch(() => {
+        toast.error("Failed to save setting");
+      });
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4 space-y-10">
+      <div>
+        <h1 className="text-3xl font-black uppercase tracking-tight text-primary">
+          Settings
+        </h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Your preferences are saved automatically.
+        </p>
+      </div>
+
+      {/* Notification Preferences */}
+      <section className="space-y-6">
+        <h2 className="text-xs font-black uppercase tracking-widest text-muted-foreground border-b pb-2">
+          Notifications
+        </h2>
+        <p className="text-xs text-muted-foreground -mt-3">
+          These settings control which in-app notification types you receive.
+        </p>
+
+        <ToggleSwitch
+          label="Outbid Alerts"
+          checked={preferences?.notificationsBidOutbid ?? true}
+          onChange={() =>
+            update({
+              notificationsBidOutbid: !(
+                preferences?.notificationsBidOutbid ?? true
+              ),
+            })
+          }
+        />
+
+        <div className="space-y-2">
+          <Label className="text-sm font-bold">Watchlist Ending Alerts</Label>
+          <Select
+            value={preferences?.notificationsWatchlistEnding ?? "1h"}
+            onValueChange={(value: "disabled" | "1h" | "3h" | "24h") =>
+              update({ notificationsWatchlistEnding: value })
+            }
+          >
+            <SelectTrigger className="w-48 h-10 rounded-xl border-2 font-bold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="disabled">Disabled</SelectItem>
+              <SelectItem value="1h">1 hour before</SelectItem>
+              <SelectItem value="3h">3 hours before</SelectItem>
+              <SelectItem value="24h">24 hours before</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <ToggleSwitch
+          label="Auction Won Notifications"
+          checked={preferences?.notificationsAuctionWon ?? true}
+          onChange={() =>
+            update({
+              notificationsAuctionWon: !(
+                preferences?.notificationsAuctionWon ?? true
+              ),
+            })
+          }
+        />
+
+        {isSeller && (
+          <ToggleSwitch
+            label="Auction Approval Notifications"
+            checked={preferences?.notificationsSellerAuctionApproved ?? true}
+            onChange={() =>
+              update({
+                notificationsSellerAuctionApproved: !(
+                  preferences?.notificationsSellerAuctionApproved ?? true
+                ),
+              })
+            }
+            description="Notify when your auction listing is approved"
+          />
+        )}
+
+        <ToggleSwitch
+          label="Email Notifications"
+          checked={preferences?.notificationsEmailEnabled ?? false}
+          onChange={() =>
+            update({
+              notificationsEmailEnabled: !(
+                preferences?.notificationsEmailEnabled ?? false
+              ),
+            })
+          }
+          description="Receive notifications via email (in addition to in-app)"
+        />
+      </section>
+
+      {/* Display Preferences */}
+      <section className="space-y-6">
+        <h2 className="text-xs font-black uppercase tracking-widest text-muted-foreground border-b pb-2">
+          Display
+        </h2>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-bold">Default View Mode</Label>
+          <Select
+            value={preferences?.viewMode ?? "detailed"}
+            onValueChange={(value: "compact" | "detailed") =>
+              update({ viewMode: value })
+            }
+          >
+            <SelectTrigger className="w-48 h-10 rounded-xl border-2 font-bold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="detailed">Detailed</SelectItem>
+              <SelectItem value="compact">Compact</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <ToggleSwitch
+          label="Show Filter Sidebar by Default"
+          checked={preferences?.sidebarOpen ?? false}
+          onChange={() =>
+            update({ sidebarOpen: !(preferences?.sidebarOpen ?? false) })
+          }
+          description="Desktop only"
+        />
+
+        <div className="space-y-2">
+          <Label className="text-sm font-bold">Default Auction Status</Label>
+          <Select
+            value={preferences?.defaultStatusFilter ?? "active"}
+            onValueChange={(value: "active" | "closed" | "all") =>
+              update({ defaultStatusFilter: value })
+            }
+          >
+            <SelectTrigger className="w-48 h-10 rounded-xl border-2 font-bold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="active">Active Auctions</SelectItem>
+              <SelectItem value="closed">Closed Auctions</SelectItem>
+              <SelectItem value="all">All Auctions</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </section>
+
+      {/* Bidding Preferences */}
+      <section className="space-y-6">
+        <h2 className="text-xs font-black uppercase tracking-widest text-muted-foreground border-b pb-2">
+          Bidding
+        </h2>
+
+        <ToggleSwitch
+          label="Require Bid Confirmation"
+          checked={preferences?.biddingRequireConfirmation ?? false}
+          onChange={() =>
+            update({
+              biddingRequireConfirmation: !(
+                preferences?.biddingRequireConfirmation ?? false
+              ),
+            })
+          }
+          description="Show a confirmation dialog before placing bids"
+        />
+
+        <ToggleSwitch
+          label="Enable Proxy Bidding by Default"
+          checked={preferences?.biddingProxyBidDefault ?? false}
+          onChange={() =>
+            update({
+              biddingProxyBidDefault: !(
+                preferences?.biddingProxyBidDefault ?? false
+              ),
+            })
+          }
+          description="Automatically bid up to your maximum amount"
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminFAQ.test.tsx
+++ b/src/pages/admin/AdminFAQ.test.tsx
@@ -74,6 +74,12 @@ const sampleFaqs: FaqItem[] = [
   },
 ];
 
+const threeFaqs: FaqItem[] = [
+  sampleFaqs[0],
+  sampleFaqs[1],
+  { ...sampleFaqs[0], _id: "faq3" as Id<"faqItems"> },
+];
+
 describe("AdminFAQ", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -212,5 +218,142 @@ describe("AdminFAQ", () => {
 
     expect(screen.getByText("Edit FAQ Item")).toBeInTheDocument();
     expect(screen.getByDisplayValue("How do I register?")).toBeInTheDocument();
+  });
+
+  it("move up button is disabled for first item", () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    render(<AdminFAQ />);
+
+    const moveUpButtons = screen.getAllByRole("button", { name: /move up/i });
+    expect(moveUpButtons[0]).toBeDisabled();
+  });
+
+  it("move down button is disabled for last item", () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled();
+  });
+
+  it("calls reorderFaqItems when move down is clicked", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockReorderFaqItems.mockResolvedValue(null);
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    fireEvent.click(moveDownButtons[0]);
+
+    await waitFor(() => {
+      expect(mockReorderFaqItems).toHaveBeenCalledWith({
+        orderedIds: ["faq2", "faq1"],
+      });
+    });
+  });
+
+  it("move up button enabled for non-first item", () => {
+    mockFaqItems = threeFaqs;
+    (useQuery as Mock).mockReturnValue(threeFaqs);
+    render(<AdminFAQ />);
+
+    const moveUpButtons = screen.getAllByRole("button", { name: /move up/i });
+    expect(moveUpButtons[1]).not.toBeDisabled();
+  });
+
+  it("move down button enabled for non-last item", () => {
+    mockFaqItems = threeFaqs;
+    (useQuery as Mock).mockReturnValue(threeFaqs);
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    expect(moveDownButtons[1]).not.toBeDisabled();
+  });
+
+  it("shows error toast when create fails", async () => {
+    mockFaqItems = [];
+    (useQuery as Mock).mockReturnValue([]);
+    mockCreateFaqItem.mockRejectedValue(new Error("Database error"));
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getByRole("button", { name: /new faq item/i }));
+    fireEvent.change(screen.getByLabelText(/question/i), {
+      target: { value: "Test Question" },
+    });
+    fireEvent.change(screen.getByLabelText(/answer/i), {
+      target: { value: "Test Answer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Database error");
+    });
+  });
+
+  it("shows error toast when toggle publish fails", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockUpdateFaqItem.mockRejectedValue(new Error("Update failed"));
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getByText("Published"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Update failed");
+    });
+  });
+
+  it("shows error toast when delete fails", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockDeleteFaqItem.mockRejectedValue(new Error("Delete failed"));
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Delete failed");
+    });
+  });
+
+  it("shows error toast when reorder fails", async () => {
+    mockFaqItems = sampleFaqs;
+    (useQuery as Mock).mockReturnValue(sampleFaqs);
+    mockReorderFaqItems.mockRejectedValue(new Error("Reorder failed"));
+    render(<AdminFAQ />);
+
+    const moveDownButtons = screen.getAllByRole("button", {
+      name: /move down/i,
+    });
+    fireEvent.click(moveDownButtons[0]);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Reorder failed");
+    });
+  });
+
+  it("shows error toast when save with empty answer", async () => {
+    mockFaqItems = [];
+    (useQuery as Mock).mockReturnValue([]);
+    render(<AdminFAQ />);
+
+    fireEvent.click(screen.getByRole("button", { name: /new faq item/i }));
+    fireEvent.change(screen.getByLabelText(/question/i), {
+      target: { value: "Test Question" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Answer is required");
+    });
   });
 });

--- a/src/pages/admin/AdminFAQ.test.tsx
+++ b/src/pages/admin/AdminFAQ.test.tsx
@@ -77,7 +77,7 @@ const sampleFaqs: FaqItem[] = [
 const threeFaqs: FaqItem[] = [
   sampleFaqs[0],
   sampleFaqs[1],
-  { ...sampleFaqs[0], _id: "faq3" as Id<"faqItems"> },
+  { ...sampleFaqs[0], _id: "faq3" as Id<"faqItems">, order: 2 },
 ];
 
 describe("AdminFAQ", () => {


### PR DESCRIPTION
## Summary

- **User preferences table** — New `userPreferences` Convex table with display (view mode, sidebar state), default filters (make, year, price, hours, status), bidding (confirmation, proxy), and notification preferences (outbid, watchlist, won, approval, email).
- **Settings page** (`/settings`) — Dedicated UI with auto-save toggles and dropdowns. Changes persist immediately on interaction — no "Save" button needed. Seller-only notification controls conditionally rendered.
- **Home page integration** — View mode, sidebar open state, and default status filter all read from saved preferences on mount and persist on toggle.
- **FilterSidebar defaults** — "Save Defaults" and "Clear Defaults" buttons persist/clear filter preferences. Clear defaults now resets URL params and local filter state to prevent stale re-application.
- **Cross-field validation** — Backend prevents invalid ranges (minYear > maxYear, minPrice > maxPrice) by comparing new values against existing stored values.
- **URL precedence** — URL query params always override saved preferences, enabling shareable filtered URLs.
- **Bug fixes** — Fixed `sidebarOpen` preference initialization (was skipped when `preferences` was `null`), fixed Clear Defaults to clear URL params, added toast feedback for filter defaults actions.

## Changed Files

| File                                     | Change                                                               |
| ---------------------------------------- | -------------------------------------------------------------------- |
| `convex/schema.ts`                       | Added `userPreferences` table with indexed `userId`                  |
| `convex/userPreferences.ts`              | New module: `getMyPreferences` query, `updateMyPreferences` mutation |
| `convex/users.ts`                        | Added `getMyProfile` query for role-aware settings                   |
| `src/pages/Settings.tsx`                 | New settings page with all preference controls                       |
| `src/pages/Home.tsx`                     | Integrated preferences for view mode, sidebar, status filter         |
| `src/components/FilterSidebar.tsx`       | Added Save/Clear Defaults with URL sync and toast feedback           |
| `src/components/Layout.test.tsx`         | Updated tests for new navigation                                     |
| `src/components/header/UserDropdown.tsx` | Added Settings link to user menu                                     |
| `src/App.tsx`                            | Added `/settings` route                                              |
| `src/components/AuctionCardSkeleton.tsx` | Minor style updates                                                  |
| `src/pages/Profile.tsx`                  | Minor updates for settings integration                               |
| `convex/users.test.ts`                   | Added tests for profile queries                                      |
| `src/pages/Settings.test.tsx`            | New comprehensive test suite (18 tests)                              |
| `src/pages/Home.test.tsx`                | Added preference-related tests                                       |
| `src/pages/Profile.test.tsx`             | Extended test coverage                                               |
| `src/components/FilterSidebar.test.tsx`  | Extended test coverage (43 tests)                                    |
| `src/pages/admin/AdminFAQ.test.tsx`      | New test file                                                        |

## Verification

- `bun run lint` — pass
- `bun run type-check` — pass
- `bun run build` — pass
- `bun run test --run` — pass
- Chrome DevTools manual testing — all preferences persist across reloads, Clear Defaults resets URL + filters, sidebar opens on load when preference is set

Closes #118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- User Preferences Persistence: Adds a new Convex table userPreferences (indexed by userId) to persist per-user UI preferences (view mode, sidebar open state), default filters (make, min/max year, min/max price, max hours, status), bidding options (require confirmation, proxy bid default), and notification preferences (outbid, watchlist ending, auction won, seller approval, email). Backend upsert mutation enforces cross-field validation (e.g., min ≤ max).
- Settings page: New protected /settings page with auto-saving toggles and selects for all preference categories; seller-only notification controls render conditionally based on profile role.
- Home integration: Home reads saved preferences on mount to restore view mode, sidebar state, and default status filter; view/sidebar toggles persist automatically for authenticated users.
- FilterSidebar defaults: Adds "Save Defaults" and "Clear Defaults" actions; saved defaults auto-apply when no URL params exist; Clear Defaults clears stored defaults, resets local filter state, and removes corresponding URL query parameters (with toast feedback).
- URL precedence: URL query parameters take precedence over saved preferences (so shareable filtered URLs continue to work).
- Profile editing: Adds inline profile editing (bio, location, companyName) and a new updateMyProfile mutation.
- API & schema: New Convex endpoints getMyPreferences and updateMyPreferences (with upsert and validation); Convex schema updated with userPreferences and index by userId.
- UX & navigation: Registers /settings route and links it in the user dropdown; minor UI/skeleton/header tweaks; toast feedback added for preference save/clear actions.
- Tests & CI: Tests added/updated across Settings, Home, Profile, FilterSidebar, users, and admin FAQ; lint, type-check, build, and tests pass locally; manual Chrome testing verified persistence, Clear Defaults behavior, and sidebar restoration on load.
- Bug fixes: Initialize sidebarOpen when preferences are null; ensure Clear Defaults clears URL params; add toast feedback for filter defaults actions.

Closes: https://github.com/marcojsmith/AgriBid/issues/118

| Author | Lines Added | Lines Removed |
|--------|------------:|-------------:|
| marcojsmith | 2,440 | 200 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->