### PR TITLE
feat: add dynamic branding context for configurable app name

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/better-auth": "^0.10.10",
+    "@opentelemetry/api": "^1.9.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@convex-dev/aggregate": "^0.2.1",
     "@convex-dev/better-auth": "^0.10.10",
-    "@opentelemetry/api": "^1.9.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,12 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, type Mock } from "vitest";
 import { BrowserRouter } from "react-router-dom";
-vi.mock("convex/react", () => ({
-  useQuery: vi.fn(),
-}));
 import { useQuery } from "convex/react";
 
 import { Footer } from "./Footer";
+
+vi.mock("@/hooks/useBranding", () => ({
+  useBranding: () => ({ appName: "AgriBid" }),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: vi.fn(),
+}));
 
 const mockUseQuery = useQuery as Mock;
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,6 +11,8 @@ import {
   MapPin,
 } from "lucide-react";
 
+import { useBranding } from "@/hooks/useBranding";
+
 /**
  * Footer component for the application.
  * Displays business info from admin settings.
@@ -18,9 +20,10 @@ import {
  * @returns The rendered footer.
  */
 export const Footer = () => {
+  const branding = useBranding();
   const businessInfo = useQuery(api.admin.getBusinessInfo);
 
-  const businessName = businessInfo?.businessName || "AgriBid";
+  const businessName = branding?.appName ?? "AgriBid";
   const streetAddress = businessInfo?.streetAddress || "";
   const addressLocality = businessInfo?.addressLocality || "";
   const addressCountry = businessInfo?.addressCountry || "";

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -37,6 +37,16 @@ vi.mock("@/lib/auth-client", () => ({
   useSession: vi.fn(),
 }));
 
+vi.mock("@/hooks/useBranding", () => ({
+  useBranding: () => ({ appName: "AgriBid" }),
+}));
+
+vi.mock("@/contexts/BrandingProvider", () => ({
+  BrandingProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
 describe("Layout", () => {
   const mockUseQuery = convexReact.useQuery as ReturnType<typeof vi.fn>;
   const mockUseMutation = convexReact.useMutation as ReturnType<typeof vi.fn>;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,8 @@ import { useLocation } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 
 import { UserProfileProvider } from "@/contexts/UserProfileContext";
+import { BrandingProvider } from "@/contexts/BrandingProvider";
+import { useBranding } from "@/hooks/useBranding";
 import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import {
@@ -25,6 +27,98 @@ import { PresenceListener } from "./PresenceListener";
 interface LayoutProps {
   children: ReactNode;
 }
+
+/**
+ * Renders Helmet tags that depend on the dynamic branding context.
+ * Must be rendered inside BrandingProvider.
+ *
+ * @param props - Component props
+ * @param props.location - Current router location for canonical URLs
+ * @param props.businessInfo - Business info for JSON-LD schema
+ * @param props.seoSettings - SEO settings for verification tags
+ * @returns Helmet element with dynamic SEO tags
+ */
+const LayoutHelmet = ({
+  location,
+  businessInfo,
+  seoSettings,
+}: {
+  location: ReturnType<typeof useLocation>;
+  businessInfo: ReturnType<typeof useQuery<typeof api.admin.getBusinessInfo>>;
+  seoSettings: ReturnType<typeof useQuery<typeof api.admin.getSeoSettings>>;
+}) => {
+  const branding = useBranding();
+
+  return (
+    <Helmet>
+      <title>{DEFAULT_TITLE}</title>
+      <meta name="description" content={DEFAULT_DESCRIPTION} />
+      <link rel="canonical" href={buildCanonical(location.pathname)} />
+      <link rel="alternate" hrefLang="en-ZA" href={SITE_URL} />
+      <meta property="og:site_name" content={branding?.appName ?? SITE_NAME} />
+      <meta property="og:title" content={DEFAULT_TITLE} />
+      <meta property="og:description" content={DEFAULT_DESCRIPTION} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={buildCanonical(location.pathname)} />
+      <meta property="og:image" content={DEFAULT_OG_IMAGE} />
+      <meta property="og:locale" content="en_ZA" />
+      <meta name="twitter:card" content="summary_large_image" />
+      {businessInfo?.businessName && (
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            name: businessInfo.businessName ?? SITE_NAME,
+            url: businessInfo.website ?? SITE_URL,
+            logo: businessInfo.logoUrl ?? `${SITE_URL}/logo.png`,
+            description:
+              businessInfo.businessDescription ?? DEFAULT_DESCRIPTION,
+            address: {
+              "@type": "PostalAddress",
+              streetAddress: businessInfo.streetAddress ?? "123 Harvest Road",
+              addressLocality:
+                businessInfo.addressLocality ?? "Agricultural Hub",
+              addressCountry: businessInfo.addressCountry ?? "ZA",
+              postalCode: businessInfo.postalCode ?? "4500",
+            },
+            contactPoint: {
+              "@type": "ContactPoint",
+              telephone: businessInfo.telephone ?? "+27-11-555-0123",
+              email: businessInfo.email ?? undefined,
+              contactType: "customer service",
+            },
+            sameAs: businessInfo.sameAs ?? [],
+          })}
+        </script>
+      )}
+      {seoSettings?.searchConsoleVerification && (
+        <meta
+          name="google-site-verification"
+          content={seoSettings.searchConsoleVerification}
+        />
+      )}
+      {seoSettings?.bingVerification && (
+        <meta name="msvalidate.01" content={seoSettings.bingVerification} />
+      )}
+      {seoSettings?.ga4MeasurementId &&
+        /^G-[A-Z0-9]{6,}$/i.test(seoSettings.ga4MeasurementId) && (
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${seoSettings.ga4MeasurementId}`}
+          />
+        )}
+      {seoSettings?.ga4MeasurementId &&
+        /^G-[A-Z0-9]{6,}$/i.test(seoSettings.ga4MeasurementId) && (
+          <script>{`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', ${JSON.stringify(seoSettings.ga4MeasurementId)});
+          `}</script>
+        )}
+    </Helmet>
+  );
+};
 
 /**
  * Main application layout component.
@@ -61,93 +155,31 @@ export const Layout = ({ children }: LayoutProps) => {
 
   return (
     <UserProfileProvider>
-      {/* Default SEO — individual pages override via their own <Helmet> */}
-      <Helmet>
-        <title>{DEFAULT_TITLE}</title>
-        <meta name="description" content={DEFAULT_DESCRIPTION} />
-        <link rel="canonical" href={buildCanonical(location.pathname)} />
-        <link rel="alternate" hrefLang="en-ZA" href={SITE_URL} />
-        <meta property="og:site_name" content={SITE_NAME} />
-        <meta property="og:title" content={DEFAULT_TITLE} />
-        <meta property="og:description" content={DEFAULT_DESCRIPTION} />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={buildCanonical(location.pathname)} />
-        <meta property="og:image" content={DEFAULT_OG_IMAGE} />
-        <meta property="og:locale" content="en_ZA" />
-        <meta name="twitter:card" content="summary_large_image" />
-        {businessInfo?.businessName && (
-          <script type="application/ld+json">
-            {JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "Organization",
-              name: businessInfo.businessName ?? SITE_NAME,
-              url: businessInfo.website ?? SITE_URL,
-              logo: businessInfo.logoUrl ?? `${SITE_URL}/logo.png`,
-              description:
-                businessInfo.businessDescription ?? DEFAULT_DESCRIPTION,
-              address: {
-                "@type": "PostalAddress",
-                streetAddress: businessInfo.streetAddress ?? "123 Harvest Road",
-                addressLocality:
-                  businessInfo.addressLocality ?? "Agricultural Hub",
-                addressCountry: businessInfo.addressCountry ?? "ZA",
-                postalCode: businessInfo.postalCode ?? "4500",
-              },
-              contactPoint: {
-                "@type": "ContactPoint",
-                telephone: businessInfo.telephone ?? "+27-11-555-0123",
-                email: businessInfo.email ?? undefined,
-                contactType: "customer service",
-              },
-              sameAs: businessInfo.sameAs ?? [],
-            })}
-          </script>
-        )}
-        {/* Dynamic analytics/verification — configured via Admin > SEO & Analytics */}
-        {seoSettings?.searchConsoleVerification && (
-          <meta
-            name="google-site-verification"
-            content={seoSettings.searchConsoleVerification}
-          />
-        )}
-        {seoSettings?.bingVerification && (
-          <meta name="msvalidate.01" content={seoSettings.bingVerification} />
-        )}
-        {seoSettings?.ga4MeasurementId &&
-          /^G-[A-Z0-9]{6,}$/i.test(seoSettings.ga4MeasurementId) && (
-            <script
-              async
-              src={`https://www.googletagmanager.com/gtag/js?id=${seoSettings.ga4MeasurementId}`}
-            />
+      <BrandingProvider>
+        <LayoutHelmet
+          location={location}
+          businessInfo={businessInfo}
+          seoSettings={seoSettings}
+        />
+        <div className="min-h-screen flex flex-col bg-background text-foreground">
+          {session && (
+            <>
+              <NotificationListener />
+              <PresenceListener />
+            </>
           )}
-        {seoSettings?.ga4MeasurementId &&
-          /^G-[A-Z0-9]{6,}$/i.test(seoSettings.ga4MeasurementId) && (
-            <script>{`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', ${JSON.stringify(seoSettings.ga4MeasurementId)});
-          `}</script>
-          )}
-      </Helmet>
-      <div className="min-h-screen flex flex-col bg-background text-foreground">
-        {session && (
-          <>
-            <NotificationListener />
-            <PresenceListener />
-          </>
-        )}
-        <Header />
-        <main
-          className={cn(
-            "flex-1",
-            !isAdminPage && "container mx-auto px-4 md:px-8 py-4 md:py-8"
-          )}
-        >
-          {children}
-        </main>
-        {!isAdminPage && <Footer />}
-      </div>
+          <Header />
+          <main
+            className={cn(
+              "flex-1",
+              !isAdminPage && "container mx-auto px-4 md:px-8 py-4 md:py-8"
+            )}
+          >
+            {children}
+          </main>
+          {!isAdminPage && <Footer />}
+        </div>
+      </BrandingProvider>
     </UserProfileProvider>
   );
 };

--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -71,6 +71,14 @@ vi.mock("@/components/NotificationDropdown", () => ({
   ),
 }));
 
+vi.mock("@/contexts/BrandingProvider", () => ({
+  BrandingProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useBranding", () => ({
+  useBranding: () => ({ appName: "AgriBid" }),
+}));
+
 describe("Header", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -59,7 +59,7 @@ export const Header = () => {
             to="/"
             className="font-black text-2xl tracking-tighter text-primary"
           >
-            {branding?.appName.toUpperCase()}
+            {(branding?.appName ?? 'APP').toUpperCase()}
           </Link>
 
           <nav

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,6 +4,7 @@ import { Authenticated, Unauthenticated, useQuery } from "convex/react";
 import { api } from "convex/_generated/api";
 import { toast } from "sonner";
 
+import { useBranding } from "@/hooks/useBranding";
 import { signOut } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -21,6 +22,7 @@ import { UserDropdown } from "./UserDropdown";
  * @returns A JSX.Element representing the application header
  */
 export const Header = () => {
+  const branding = useBranding();
   const userData = useQuery(api.users.getMyProfile);
   const isLoadingProfile = userData === undefined;
   const profileId = userData?.profile?.userId;
@@ -57,7 +59,7 @@ export const Header = () => {
             to="/"
             className="font-black text-2xl tracking-tighter text-primary"
           >
-            AGRIBID
+            {branding?.appName.toUpperCase()}
           </Link>
 
           <nav

--- a/src/contexts/BrandingProvider.tsx
+++ b/src/contexts/BrandingProvider.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+import { api } from "convex/_generated/api";
+
+import { BrandingContext } from "@/hooks/useBranding";
+import { SITE_NAME } from "@/lib/seo";
+
+/**
+ * Supply the application's branding values to descendant components.
+ *
+ * Fetches business info from the backend and derives `appName` from the
+ * configured business name, falling back to `SITE_NAME` ("AgriBid") while
+ * loading or when the value is unavailable.
+ *
+ * @param props - Component props
+ * @param props.children - React nodes to render inside the provider
+ * @returns A React element wrapping children in BrandingContext.Provider
+ */
+export function BrandingProvider({ children }: { children: ReactNode }) {
+  const result = useQuery(api.admin.getBusinessInfo);
+
+  // During loading (undefined) or when the value is null/empty, fall back to
+  // the static SITE_NAME so children never receive undefined.
+  const rawName = result?.businessName;
+  const appName =
+    typeof rawName === "string" && rawName.trim() !== ""
+      ? rawName.trim()
+      : SITE_NAME;
+
+  const value = useMemo(() => ({ appName }), [appName]);
+
+  return (
+    <BrandingContext.Provider value={value}>
+      {children}
+    </BrandingContext.Provider>
+  );
+}

--- a/src/hooks/useBranding.ts
+++ b/src/hooks/useBranding.ts
@@ -1,0 +1,13 @@
+import { createTypedContext } from "@/contexts/createTypedContext";
+
+/**
+ * Branding values exposed to all UI components through React context.
+ *
+ * @property appName - The application's business name (e.g. "AgriBid")
+ */
+export interface Branding {
+  appName: string;
+}
+
+export const [BrandingContext, useBranding] =
+  createTypedContext<Branding>("Branding");

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -17,6 +17,10 @@ vi.mock("@/lib/auth-client", () => ({
   },
 }));
 
+vi.mock("@/hooks/useBranding", () => ({
+  useBranding: () => ({ appName: "AgriBid" }),
+}));
+
 describe("Login Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useSearchParams, Navigate } from "react-router-dom";
 
+import { useBranding } from "@/hooks/useBranding";
 import { useSession, signIn, signUp } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,6 +16,7 @@ import { LoadingPage } from "@/components/LoadingIndicator";
  * @returns The Login page JSX element
  */
 export default function Login() {
+  const branding = useBranding();
   const { data: session, isPending } = useSession();
   const [searchParams] = useSearchParams();
   const [email, setEmail] = useState("");
@@ -43,7 +45,7 @@ export default function Login() {
     >
       <div className="text-center">
         <h2 className="text-3xl font-black text-primary mb-2 uppercase tracking-tight">
-          AgriBid Access
+          {branding?.appName ?? "AgriBid"} Access
         </h2>
         <p className="text-muted-foreground text-sm uppercase tracking-widest">
           {authMode === "signin"
@@ -170,7 +172,7 @@ export default function Login() {
           {authMode === "signin"
             ? signInLoading
               ? "Signing in..."
-              : "Sign In to AgriBid"
+              : `Sign In to ${branding?.appName ?? "AgriBid"}`
             : signUpLoading
               ? "Creating account..."
               : "Create Verified Account"}

--- a/src/pages/admin/AdminBusinessInfo.tsx
+++ b/src/pages/admin/AdminBusinessInfo.tsx
@@ -177,6 +177,10 @@ export default function AdminBusinessInfo() {
           <CardContent className="space-y-6">
             <div className="space-y-2 pt-4 border-t">
               <Label htmlFor="business-name">Organization Name</Label>
+              <p className="text-xs text-muted-foreground">
+                This name is displayed across the platform as the application
+                name.
+              </p>
               <Input
                 id="business-name"
                 type="text"

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -7,7 +7,7 @@ import {
   Bug,
   Search,
   HelpCircle,
-  Building2,
+  Palette,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
@@ -51,6 +51,12 @@ export default function AdminSettings() {
       <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <SettingsCard
+            title="Branding"
+            description="Configure application name and identity."
+            icon={<Palette />}
+            action={() => navigate("/admin/business-info")}
+          />
+          <SettingsCard
             title="Equipment Metadata"
             description="Manage makes, models, and categories."
             icon={<Hammer />}
@@ -79,12 +85,6 @@ export default function AdminSettings() {
             description="Configure GA4, Search Console, and Bing verification."
             icon={<Search />}
             action={() => navigate("/admin/seo")}
-          />
-          <SettingsCard
-            title="Business Info"
-            description="Organization details used for SEO structured data (JSON-LD)"
-            icon={<Building2 />}
-            action={() => navigate("/admin/business-info")}
           />
           <SettingsCard
             title="FAQ Management"


### PR DESCRIPTION
## Summary

- Expose the application's business name through a shared React context backed by the existing getBusinessInfo query, replacing every hardcoded AgriBid brand string in the UI
- Add a Branding card as the first entry in the Admin Settings hub, linking to the Business Info page
- Extract LayoutHelmet subcomponent for branding-dependent SEO tags with proper type safety

## Changes

| File | Action |
|---|---|
| src/hooks/useBranding.ts | Create - Branding interface, BrandingContext, useBranding hook |
| src/contexts/BrandingProvider.tsx | Create - fetches business info, derives appName with useMemo, falls back to SITE_NAME |
| src/components/Layout.tsx | Modify - mount BrandingProvider, extract LayoutHelmet for SEO tags |
| src/components/header/Header.tsx | Modify - dynamic appName from context |
| src/components/Footer.tsx | Modify - appName from context; keep contact fields query |
| src/pages/Login.tsx | Modify - dynamic brand strings with safe fallbacks |
| src/pages/admin/AdminSettings.tsx | Modify - add Branding card, remove duplicate Business Info card |
| src/pages/admin/AdminBusinessInfo.tsx | Modify - helper text under Organization Name label |
| src/components/*.test.tsx, src/pages/*.test.tsx | Modify - update mocks for useBranding |

## Verification

- bun run type-check passes
- bun run build passes
- bun run lint passes (only pre-existing warnings)
- 75+ tests pass across affected files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Introduces dynamic branding: added a shared Branding context and useBranding hook to expose the application/business name from backend business info and replace hardcoded "AgriBid" strings across the UI.
- Branding provider & hook: added BrandingProvider (src/contexts/BrandingProvider.tsx) which fetches business info, derives a trimmed appName with fallback to SITE_NAME, and memoizes the context value; added typed useBranding hook (src/hooks/useBranding.ts).
- Component updates: Header, Footer, and Login now consume dynamic appName from useBranding with safe fallbacks; Footer continues to fetch contact fields from business info.
- Layout & SEO: extracted LayoutHelmet subcomponent in Layout to render branding-dependent SEO/meta tags (og:site_name now uses dynamic appName) and mounted BrandingProvider at the app/layout level.
- Admin changes: added a Branding card (Palette icon) in Admin Settings linking to Business Info and removed a duplicate Business Info card; added helper text in AdminBusinessInfo clarifying Organization Name is shown as the application name.
- Tests: updated tests and mocks across components and pages to mock useBranding/BrandingProvider appropriately (75+ tests across affected files reported).
- Verification: type-check, build, and lint pass locally (bun run type-check, bun run build, bun run lint); 75+ tests pass for affected files.

Closes: https://github.com/marcojsmith/AgriBid/issues/230

| Contributing author | Lines added | Lines removed |
|---|---:|---:|
| Unavailable in this environment | — | — |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->